### PR TITLE
Fix WSO2 IS restarts when puppet agent is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,55 +124,33 @@ Uncomment and modify the below changes in Hiera file to apply Secure Vault.
     wso2::enable_secure_vault: true
     ```
 
-2. Add Secure Vault configurations as below
+2. Run the ciphertool.sh / ciphertool.bat (in <WSO2_HOME>/bin) with -Dconfigure parameter and enter the primary keystore password of carbon server.
 
-    ```yaml
-    wso2::secure_vault_configs:
-      <secure_vault_config_name>:
-        secret_alias: <secret_alias>
-        secret_alias_value: <secret_alias_value>
-        password: <password>
-    ```
+```bash
+sh ciphertool.sh -Dconfigure
+[Please Enter Primary KeyStore Password of Carbon Server : ]
 
-    Ex:
-    ```yaml
-    wso2::secure_vault_configs:
-      key_store_password:
-        secret_alias: Carbon.Security.KeyStore.Password
-        secret_alias_value: repository/conf/carbon.xml//Server/Security/KeyStore/Password,false
-        password: wso2carbon
-    ```
+```
 
-    For Identity Server `5.0.0` which is based on WSO2 Carbon Kernel 4.2.0
+3. Copy repository/conf/security/cipher-tool.properties, repository/conf/security/cipher-text.properties, repository/conf/security/secret-conf.properties in <WSO2_HOME>/repository/conf/security to 
+'/etc/puppet/environments/production/modules/wso2is/files/configs/repository/conf/security'
 
-    Ex:
-    ```yaml
-    wso2::secure_vault_configs:
-      key_store_password:
-        secret_alias: Carbon.Security.KeyStore.Password
-        secret_alias_value: carbon.xml//Server/Security/KeyStore/Password,true
-        password: wso2carbon
-    ```
+4. Create a file named 'password-tmp' containing the the primary keystore password of carbon server in 
+'/etc/puppet/environments/production/modules/wso2is/files/configs'
 
-3. Add Cipher Tool configuration file templates to `template_list`
+5. Add the following configurations
+   
+```yaml
+# Puppet file list to be populated
+ wso2::file_list:
+  - repository/conf/security/cipher-tool.properties
+  - repository/conf/security/cipher-text.properties
+  - repository/conf/security/secret-conf.properties
 
-    ```yaml
-    wso2::template_list:
-      - repository/conf/security/cipher-text.properties
-      - repository/conf/security/cipher-tool.properties
-      - bin/ciphertool.sh
-    ```
-
-    Please add the `password-tmp` template also to `template_list` if the `vm_type` is not `docker` when you are running the server in `default` platform.
-
-4. For IS 5.3.0, encrypting KeyStore and TrustStore passwords in `EndpointConfig.properties` using Cipher Tool fails to deploy `authenticationendpoint` web app. This is due to a class loading issue as reported in [JIRA: IDENTITY-4276](https://wso2.org/jira/browse/IDENTITY-4276). To fix this follow the below steps:
-   - get the `authenticationendpoint.war` in CARBON_HOME/repository/deployment/server/webapps folder, remove the `org.wso2.securevault-1.0.0-wso2v2.jar` from webapp's WEB_INF/lib folder and add it to `files/configs/repository/deployment/server` folder
-   - Add the `authenticationendpoint.war` file path to `file_list` in default.yaml file
-
-    ```yaml
-    wso2::file_list:
-      - repository/deployment/server/webapps/authenticationendpoint.war
-    ```
+# Puppet file list to be populated without triggering refresh
+wso2::file_list_copy_without_refresh:
+  - password-tmp
+```
 
 ## Running WSO2 Identity Server on Kubernetes
 WSO2 Puppet Module ships Hiera data required to deploy WSO2 Identity Server on Kubernetes. For more information refer to the documentation on [deploying WSO2 products on Kubernetes using WSO2 Puppet Modules](https://docs.wso2.com/display/PM210/Deploying+WSO2+Products+on+Kubernetes+Using+WSO2+Puppet+Modules).

--- a/README.md
+++ b/README.md
@@ -147,10 +147,16 @@ sh ciphertool.sh -Dconfigure
   - repository/conf/security/cipher-text.properties
   - repository/conf/security/secret-conf.properties
 
-# Puppet file list to be populated without triggering refresh
-wso2::file_list_copy_without_refresh:
+# Puppet file list to be populated without triggering service refresh
+wso2::service_refresh_file_list:
   - password-tmp
 ```
+
+For more information please refer [Using WSO2 Carbon Secure Vault with WSO2 Puppet Modules](https://github.com/wso2/puppet-base/wiki/Using-WSO2-Carbon-Secure-Vault-With-WSO2-Puppet-Modules)
+
+## System Service Re-starts
+
+The system service will only restart for distribution changes or configuration changes.
 
 ## Running WSO2 Identity Server on Kubernetes
 WSO2 Puppet Module ships Hiera data required to deploy WSO2 Identity Server on Kubernetes. For more information refer to the documentation on [deploying WSO2 products on Kubernetes using WSO2 Puppet Modules](https://docs.wso2.com/display/PM210/Deploying+WSO2+Products+on+Kubernetes+Using+WSO2+Puppet+Modules).

--- a/hieradata/dev/wso2/wso2is/pattern-1/default.yaml
+++ b/hieradata/dev/wso2/wso2is/pattern-1/default.yaml
@@ -52,13 +52,15 @@ wso2::template_list:
 #     http: 80
 #     https: 443
 
-# Puppet file list to be populated
+# File list to be copied to the product folder, if there are changes found in the files, the system
+# service will be restarted
 # wso2::file_list:
 #  - repository/conf/security/cipher-tool.properties
 #  - repository/conf/security/cipher-text.properties
 #  - repository/conf/security/secret-conf.properties
 
-#wso2::file_list_copy_without_refresh:
+# Files to be copied to the product folder when restarting the system service
+#wso2::service_refresh_file_list:
 #  - password-tmp
 #  - "repository/components/lib/%{hiera('wso2::datasources::mysql::connector_jar')}"
 

--- a/hieradata/dev/wso2/wso2is/pattern-1/default.yaml
+++ b/hieradata/dev/wso2/wso2is/pattern-1/default.yaml
@@ -37,7 +37,6 @@ wso2::template_list:
 #  - repository/conf/security/cipher-text.properties
 #  - repository/conf/security/cipher-tool.properties
 #  - bin/ciphertool.sh
-#  - password-tmp
 
 # Provide the server list for setting up sso
 #wso2::sso_service_providers:
@@ -58,6 +57,8 @@ wso2::template_list:
 #  - repository/conf/security/cipher-tool.properties
 #  - repository/conf/security/cipher-text.properties
 #  - repository/conf/security/secret-conf.properties
+
+#wso2::file_list_copy_without_refresh:
 #  - password-tmp
 #  - "repository/components/lib/%{hiera('wso2::datasources::mysql::connector_jar')}"
 

--- a/hieradata/dev/wso2/wso2is/pattern-1/key-manager.yaml
+++ b/hieradata/dev/wso2/wso2is/pattern-1/key-manager.yaml
@@ -30,7 +30,6 @@ wso2::template_list:
   - repository/conf/identity/EndpointConfig.properties
   - repository/conf/datasources/am-datasources.xml
 #  - bin/ciphertool.sh
-#  - password-tmp
 
 # Provide the server list for setting up sso
 #wso2::sso_service_providers:
@@ -51,6 +50,8 @@ wso2::template_list:
 #  - repository/conf/security/cipher-tool.properties
 #  - repository/conf/security/cipher-text.properties
 #  - repository/conf/security/secret-conf.properties
+
+#wso2::file_list_copy_without_refresh:
 #  - password-tmp
 
 wso2::clustering:

--- a/hieradata/dev/wso2/wso2is/pattern-1/key-manager.yaml
+++ b/hieradata/dev/wso2/wso2is/pattern-1/key-manager.yaml
@@ -45,13 +45,15 @@ wso2::template_list:
 #     http: 80
 #     https: 443
 
-# Puppet file list to be populated
+# File list to be copied to the product folder, if there are changes found in the files, the system
+# service will be restarted
 # wso2::file_list:
 #  - repository/conf/security/cipher-tool.properties
 #  - repository/conf/security/cipher-text.properties
 #  - repository/conf/security/secret-conf.properties
 
-#wso2::file_list_copy_without_refresh:
+# Files to be copied to the product folder when restarting the system service
+#wso2::service_refresh_file_list:
 #  - password-tmp
 
 wso2::clustering:

--- a/hieradata/dev/wso2/wso2is/pattern-2/default.yaml
+++ b/hieradata/dev/wso2/wso2is/pattern-2/default.yaml
@@ -30,7 +30,6 @@ wso2::template_list:
   - repository/conf/identity/EndpointConfig.properties
   - repository/conf/datasources/am-datasources.xml
 #  - bin/ciphertool.sh
-#  - password-tmp
 
 # Provide the server list for setting up sso
 #wso2::sso_service_providers:
@@ -51,6 +50,8 @@ wso2::template_list:
 #  - repository/conf/security/cipher-tool.properties
 #  - repository/conf/security/cipher-text.properties
 #  - repository/conf/security/secret-conf.properties
+
+#wso2::file_list_copy_without_refresh:
 #  - password-tmp
 
 wso2::clustering:

--- a/hieradata/dev/wso2/wso2is/pattern-2/default.yaml
+++ b/hieradata/dev/wso2/wso2is/pattern-2/default.yaml
@@ -45,13 +45,16 @@ wso2::template_list:
 #     http: 80
 #     https: 443
 
+# File list to be copied to the product folder, if there are changes found in the files, the system
+# service will be restarted
 # wso2::file_list:
 #  - "repository/components/lib/%{hiera('wso2::datasources::mysql::connector_jar')}"
 #  - repository/conf/security/cipher-tool.properties
 #  - repository/conf/security/cipher-text.properties
 #  - repository/conf/security/secret-conf.properties
 
-#wso2::file_list_copy_without_refresh:
+# Files to be copied to the product folder when restarting the system service
+#wso2::service_refresh_file_list:
 #  - password-tmp
 
 wso2::clustering:

--- a/hieradata/dev/wso2/wso2is/pattern-2/key-manager.yaml
+++ b/hieradata/dev/wso2/wso2is/pattern-2/key-manager.yaml
@@ -30,7 +30,6 @@ wso2::template_list:
   - repository/conf/identity/EndpointConfig.properties
   - repository/conf/datasources/am-datasources.xml
 #  - bin/ciphertool.sh
-#  - password-tmp
 
 # Provide the server list for setting up sso
 #wso2::sso_service_providers:
@@ -51,6 +50,8 @@ wso2::template_list:
 #  - repository/conf/security/cipher-tool.properties
 #  - repository/conf/security/cipher-text.properties
 #  - repository/conf/security/secret-conf.properties
+
+#wso2::file_list_copy_without_refresh:
 #  - password-tmp
 
 wso2::clustering:

--- a/hieradata/dev/wso2/wso2is/pattern-2/key-manager.yaml
+++ b/hieradata/dev/wso2/wso2is/pattern-2/key-manager.yaml
@@ -45,13 +45,16 @@ wso2::template_list:
 #     http: 80
 #     https: 443
 
+# File list to be copied to the product folder, if there are changes found in the files, the system
+# service will be restarted
 # wso2::file_list:
 #  - "repository/components/lib/%{hiera('wso2::datasources::mysql::connector_jar')}"
 #  - repository/conf/security/cipher-tool.properties
 #  - repository/conf/security/cipher-text.properties
 #  - repository/conf/security/secret-conf.properties
 
-#wso2::file_list_copy_without_refresh:
+# Files to be copied to the product folder when restarting the system service
+#wso2::service_refresh_file_list:
 #  - password-tmp
 
 wso2::clustering:

--- a/hieradata/dev/wso2/wso2is/pattern-3/default.yaml
+++ b/hieradata/dev/wso2/wso2is/pattern-3/default.yaml
@@ -52,18 +52,16 @@ wso2::template_list:
 #     http: 80
 #     https: 443
 
-# Puppet file list to be populated
+# File list to be copied to the product folder, if there are changes found in the files, the system
+# service will be restarted
 # wso2::file_list:
-#  - repository/conf/security/cipher-tool.properties
-#  - repository/conf/security/cipher-text.properties
-#  - repository/conf/security/secret-conf.properties
-#  - password-tmp
 #  - "repository/components/lib/%{hiera('wso2::datasources::mysql::connector_jar')}"
 #  - repository/conf/security/cipher-tool.properties
 #  - repository/conf/security/cipher-text.properties
 #  - repository/conf/security/secret-conf.properties
 
-#wso2::file_list_copy_without_refresh:
+# Files to be copied to the product folder when restarting the system service
+#wso2::service_refresh_file_list:
 #  - password-tmp
 
 wso2::clustering:

--- a/hieradata/dev/wso2/wso2is/pattern-3/default.yaml
+++ b/hieradata/dev/wso2/wso2is/pattern-3/default.yaml
@@ -37,7 +37,6 @@ wso2::template_list:
 #  - repository/conf/security/cipher-text.properties
 #  - repository/conf/security/cipher-tool.properties
 #  - bin/ciphertool.sh
-#  - password-tmp
 
 # Provide the server list for setting up sso
 #wso2::sso_service_providers:
@@ -60,6 +59,12 @@ wso2::template_list:
 #  - repository/conf/security/secret-conf.properties
 #  - password-tmp
 #  - "repository/components/lib/%{hiera('wso2::datasources::mysql::connector_jar')}"
+#  - repository/conf/security/cipher-tool.properties
+#  - repository/conf/security/cipher-text.properties
+#  - repository/conf/security/secret-conf.properties
+
+#wso2::file_list_copy_without_refresh:
+#  - password-tmp
 
 wso2::clustering:
   enabled: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,6 +148,6 @@ class wso2is (
   contain wso2base::service
 
   Class['::wso2base'] -> Class['::wso2base::system']
-  -> Class['::wso2base::clean'] -> Class['::wso2base::install']
-  -> Class['::wso2is::configure'] ~> Class['::wso2base::service']
+  -> Class['::wso2base::install'] -> Class['::wso2is::configure']
+  ~> Class['::wso2base::service']
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class wso2is::params {
     $packages                 = hiera_array('packages', undef)
     $template_list            = hiera_array('wso2::template_list')
     $file_list                = hiera_array('wso2::file_list', undef)
+    $file_list_copy_without_refresh    = hiera_array('wso2::file_list_copy_without_refresh', undef)
     $patch_list               = hiera('wso2::patch_list', undef)
     $system_file_list         = hiera_hash('wso2::system_file_list', undef)
     $directory_list           = hiera_array('wso2::directory_list', undef)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,7 @@ class wso2is::params {
     $packages                 = hiera_array('packages', undef)
     $template_list            = hiera_array('wso2::template_list')
     $file_list                = hiera_array('wso2::file_list', undef)
-    $file_list_copy_without_refresh    = hiera_array('wso2::file_list_copy_without_refresh', undef)
+    $service_refresh_file_list = hiera_array('wso2::service_refresh_file_list', undef)
     $patch_list               = hiera('wso2::patch_list', undef)
     $system_file_list         = hiera_hash('wso2::system_file_list', undef)
     $directory_list           = hiera_array('wso2::directory_list', undef)


### PR DESCRIPTION
This PR adopts the puppet base changes done in PR https://github.com/wso2/puppet-base/pull/33 to avoid distribution restarts every time puppet agent polls when puppet agent is enabled. Furthermore, the PR also avoids using Clean.pp which triggers distribution restart always.

Resolves #20 