### PR TITLE
Revert removing the execution of Clean class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,6 +148,6 @@ class wso2is (
   contain wso2base::service
 
   Class['::wso2base'] -> Class['::wso2base::system']
-  -> Class['::wso2base::install'] -> Class['::wso2is::configure']
-  ~> Class['::wso2base::service']
+  -> Class['::wso2base::clean'] -> Class['::wso2base::install']
+  -> Class['::wso2is::configure'] ~> Class['::wso2base::service']
 }


### PR DESCRIPTION
Reverted removing the execution of clean class to ensure backward
compatibility with older puppet base versions