### PR TITLE
Adding missing property in user-mgt template

### DIFF
--- a/templates/repository/conf/user-mgt.xml.erb
+++ b/templates/repository/conf/user-mgt.xml.erb
@@ -34,6 +34,7 @@
             </AdminUser>
             <EveryOneRoleName>everyone</EveryOneRoleName> <!-- By default users in this role sees the registry root -->
             <Property name="isCascadeDeleteEnabled">true</Property>
+            <Property name="initializeNewClaimManager">true</Property>
             <Property name="dataSource"><%= @master_datasources[@usermgt_datasource]['jndi_config'] %></Property>
         </Configuration>
 


### PR DESCRIPTION
<Property name="initializeNewClaimManager">true</Property> is missing in usermgt template. Adding it now.

## Purpose
Fixing the EmailOTP issue due to missing property in user mgt template

## Goals
NA

## Approach
NA

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Certification
NA

## Marketing
NA

## Automation tests
NA

## Security checks
NA

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
NA 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.