### PR TITLE
Update wso2is_analytics module for minimum HA deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,16 @@ locations, in puppet master.
 ## Configure Hiera
 
 ##### Deployment Pattern 1                                                                                                                                                          
-* [Hiera YAML file](wso2is/hieradata/dev/wso2/wso2is/pattern-1/default.yaml) defined under pattern-1                                  
-(wso2is/hieradata/dev/wso2/wso2is/pattern-1) directory of wso2is module includes configurations with respect to                        
+* [Hiera YAML file](wso2is/hieradata/dev/wso2/wso2is/pattern-1/default.yaml) defined under pattern-1
+(wso2is/hieradata/dev/wso2/wso2is/pattern-1) directory of wso2is module includes configurations with respect to
 this deployment pattern for WSO2 Identity Server. 
 Configure hiera for WSO2 Identity Server following the [README](wso2is/hieradata/dev/wso2/wso2is/pattern-1/) under 
 pattern-1 directory. 
 
 ##### Deployment Pattern 2                  
-* [Hiera YAML file](wso2is/hieradata/dev/wso2/wso2is/pattern-2/default.yaml) defined under pattern-2            
-(wso2is/hieradata/dev/wso2/wso2is/pattern-2) directory of wso2is module includes configurations with respect to 
-this deployment pattern for WSO2 Identity Server. 
+* [Hiera YAML file](wso2is/hieradata/dev/wso2/wso2is/pattern-2/default.yaml) defined under pattern-2
+(wso2is/hieradata/dev/wso2/wso2is/pattern-2) directory of wso2is module includes configurations with respect to this
+ deployment pattern for WSO2 Identity Server. 
 Configure hiera for WSO2 Identity Server following the [README](wso2is/hieradata/dev/wso2/wso2is/pattern-2/) under 
 pattern-2 directory. 
 * [Hiera YAML file](wso2is_analytics/hieradata/dev/wso2/wso2is_analytics/pattern-1/default.yaml) defined under pattern-1

--- a/wso2is/hieradata/dev/wso2/wso2is/pattern-1/README.md
+++ b/wso2is/hieradata/dev/wso2/wso2is/pattern-1/README.md
@@ -1,6 +1,7 @@
 # WSO2 Identity Server Pattern-1
 
-WSO2 Identity Server Deployment Pattern 1 runs two Identity Server instances fronted with a load balancer. Identity 
+[WSO2 Identity Server Deployment Pattern 1](https://docs.wso2.com/display/IS540/Deployment+Patterns#DeploymentPatterns-Pattern1-HAclustereddeploymentofWSO2IdentityServer) 
+runs two Identity Server instances fronted with a load balancer. Identity 
 Server nodes are clustered and a shared file system or a synchronization mechanism like rsync can be used to synchronize 
 runtime artifacts.
 
@@ -16,6 +17,7 @@ Follow the given steps below, to configure hiera YAML with respect to the deploy
     Update ```wso2::hostname``` and ```wso2::mgt_hostname``` in the [default.yaml](default.yaml) file with the DNS name 
     of the load balancer. If the environment does not have a load balancer, then make sure to add the hostname mapping to 
     /etc/hosts file. 
+    
     e.g:
     ```
     wso2::hostname: is.wso2.com
@@ -26,6 +28,7 @@ Follow the given steps below, to configure hiera YAML with respect to the deploy
     Configure the JDBC driver file name under ```wso2::file_list``` or in common.yaml. For MYSQL there is an 
     entry in common.yaml as ```wso2::datasources::mysql::connector_jar``` which is then referred by the [default.yaml]
     (default.yaml) file here.
+    
     e.g:
      ```
      wso2::file_list:
@@ -36,6 +39,7 @@ Follow the given steps below, to configure hiera YAML with respect to the deploy
     Configure a clustering scheme under ```wso2::clustering```. By default, WKA related configurations are added. 
     Update the member list under WKA scheme in [default.yaml](default.yaml) file with the ip addresses of the members
      participating in the cluster.
+     
     e.g:
     ```
     membership_scheme: wka
@@ -69,6 +73,7 @@ Follow the given steps below, to configure hiera YAML with respect to the deploy
     * Datasource in repository/conf/master-datasources.xml file:
     
     A single datasource can be configured to be used with used for registry, user management and identity
+    
     e.g:
     ```
     wso2::master_datasources:
@@ -90,6 +95,7 @@ Follow the given steps below, to configure hiera YAML with respect to the deploy
     * BPS datasource in repository/conf/datasources/bps-datasources.xml file:
     
     Datasource used to manage the embedded BPS engine related data.
+    
     e.g:
     ```
     wso2::bps_datasources:
@@ -113,6 +119,7 @@ Follow the given steps below, to configure hiera YAML with respect to the deploy
 5. Configure user store.
 
    Configure a JDBC user store, LDAP or an Active Directory, with connection URL, connection username and password.
+   
    e.g:
    ```
    wso2::user_store:
@@ -124,9 +131,8 @@ Follow the given steps below, to configure hiera YAML with respect to the deploy
          username: "%{hiera('wso2::datasources::mysql::username')}"
          password: "%{hiera('wso2::datasources::mysql::password')}"
    ```
- 6. In the puppet agent set below factor variables as explained in [wiki](https://github
- .com/wso2/puppet-base/wiki/Use-WSO2-Puppet-Modules-in-puppet-master-agent-Environment#task-3---set-facter-variables
- -and-perform-a-puppet-agent-run), and run puppet agent
+ 6. In the puppet agent set below factor variables as explained in 
+ [wiki](https://github.com/wso2/puppet-base/wiki/Use-WSO2-Puppet-Modules-in-puppet-master-agent-Environment#task-3---set-facter-variables-and-perform-a-puppet-agent-run), and run puppet agent
     ```
     product_name=wso2is
     product_version=5.4.0

--- a/wso2is_analytics/hieradata/dev/wso2/wso2is_analytics/pattern-1/README.md
+++ b/wso2is_analytics/hieradata/dev/wso2/wso2is_analytics/pattern-1/README.md
@@ -2,15 +2,12 @@
 
 [WSO2 Identity Server Deployment Pattern 2](https://docs.wso2.com/display/IS540/Deployment+Patterns#DeploymentPatterns-Pattern2-HAclustereddeploymentofWSO2IdentityServerwithWSO2IdentityAnalytics) 
 runs two Identity Server instances fronted with a load balancer with WSO2 
-Identity Analytics Server. As WSO2 Identity Analytics Server component is not mission critical, a single node 
-deployment of a WSO2 Identity Analytics Server or the [minimum HA deployment of WSO2 Identity Analytics Server](https://docs.wso2.com/display/IS540/Setting+Up+Deployment+Pattern+2#SettingUpDeploymentPattern2-MinimumHighAvailabilityDeploymentforWSO2ISAnalytics) 
-can be done.
+Identity Analytics [minimum high availability deployment](https://docs.wso2.com/display/IS540/Setting+Up+Deployment+Pattern+2#SettingUpDeploymentPattern2-MinimumHighAvailabilityDeploymentforWSO2ISAnalytics). 
 
 ![alt tag](../../../../../../patterns/images/deployment-architecture-pattern-2.png)
   
-The hiera YAML in this directory can be used to setup WSO2 Identity Analytics Server nodes participating in the 
+The hiera YAML in this directory can be used to setup each WSO2 Identity Analytics Server node participating in the 
 above deployment.
-Default configurations in the hiera YAML is to setup a single node deployment of WSO2 Identity Analytics Server.
 
 Follow the given steps below, to configure hiera YAML with respect to the deployment.
 
@@ -29,6 +26,7 @@ Follow the given steps below, to configure hiera YAML with respect to the deploy
     Configure the JDBC driver file name under ```wso2::file_list``` or in common.yaml. For MYSQL there is an 
     entry in common.yaml as ```wso2::datasources::mysql::connector_jar``` which is then referred by the [default.yaml]
     (default.yaml) file here.
+    
     e.g:
      ```
      wso2::file_list:
@@ -52,6 +50,7 @@ Follow the given steps below, to configure hiera YAML with respect to the deploy
     * Datasource in repository/conf/master-datasources.xml file:
     
     A single datasource can be configured for registry and user management
+    
     e.g:
     ```
     wso2::master_datasources:
@@ -70,46 +69,72 @@ Follow the given steps below, to configure hiera YAML with respect to the deploy
           validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
           validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
     ```
-    * Analytics record store datasource in repository/conf/datasources/analytics-datasources.xml file:
+    * Analytics event store datasource in repository/conf/datasources/analytics-datasources.xml file:
     
-    Datasource used Analytics record store. In default configurations analytics event store and processed data store 
-    is not separated out and a single datasource is configured and used for both. If needed two databases can be 
-    defined and two datasources can be configured as in [minimum HA deployment guideline](https://docs.wso2.com/display/IS540/Setting+Up+Deployment+Pattern+2#SettingUpDeploymentPattern2-MinimumHighAvailabilityDeploymentforWSO2ISAnalytics). 
+    Datasource used for analytics event store. It is recommended to configure a separate database that is read write 
+    optimized as the analytics event store. For more details refer
+     [minimum HA deployment guideline](https://docs.wso2.com/display/IS540/Setting+Up+Deployment+Pattern+2#SettingUpDeploymentPattern2-MinimumHighAvailabilityDeploymentforWSO2ISAnalytics) for WSO2 Identity Analytics. 
+    
     e.g:
     ```
     wso2::analytics_datasources:
-      analytics_store_ds:
-        name: WSO2_ANALYTICS_STORE_DS
-        description: The datasource used for analytics record store
-        driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
-        url: jdbc:mysql://192.168.100.1:3306/WSO2_ANALYTICS_DB?autoReconnect=true&amp;useSSL=false
-        username: "%{hiera('wso2::datasources::mysql::username')}"
-        password: "%{hiera('wso2::datasources::mysql::password')}"
-        max_active: "%{hiera('wso2::datasources::common::max_active')}"
-        max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
-        test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
-        default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
-        validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
-        validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
-        default_auto_commit: false
-        initial_size: 0
-        test_while_idle: true
-        min_evictable_idle_time_millis: 4000
+      analytics_event_store_ds:
+          name: WSO2_ANALYTICS_EVENT_STORE_DS
+          description: The datasource used for analytics record store
+          driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
+          url: "jdbc:%{hiera('wso2::rdbms::engine')}://%{hiera('wso2::rdbms::hostname')}:%{hiera('wso2::rdbms::port')}/WSO2_ANALYTICS_EVENT_STORE_DB?autoReconnect=true&amp;useSSL=false"
+          username: "%{hiera('wso2::datasources::mysql::username')}"
+          password: "%{hiera('wso2::datasources::mysql::password')}"
+          max_active: "%{hiera('wso2::datasources::common::max_active')}"
+          max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
+          test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
+          default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
+          validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
+          validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
+          default_auto_commit: false
+          initial_size: 0
+          test_while_idle: true
+          min_evictable_idle_time_millis: 4000
         
      # Analytics event store datasource configuration in repository/conf/analytics/analytics-config.xml
-     wso2::analytics_event_store_datasource: analytics_store_ds
-     
-     # Analytics processed data store datasource configuration in repository/conf/analytics/analytics-config.xml
-     wso2::analytics_processed_data_store_datasource: analytics_store_ds
+     wso2::analytics_event_store_datasource: analytics_event_store_ds
     ```
+      * Analytics processed data store datasource in repository/conf/datasources/analytics-datasources.xml file:
+        
+        Datasource used for analytics processed data store. It is recommended to configure a separate database that is 
+        write optimized as the analytics event store. For more details refer
+         [minimum HA deployment guideline](https://docs.wso2.com/display/IS540/Setting+Up+Deployment+Pattern+2#SettingUpDeploymentPattern2-MinimumHighAvailabilityDeploymentforWSO2ISAnalytics) for WSO2 Identity Analytics. 
+        
+        e.g:
+        ```
+        wso2::analytics_datasources:
+          analytics_processed_data_store_ds:
+              name: WSO2_ANALYTICS_PROCESSED_DATA_STORE_DS
+              description: The datasource used for analytics record store
+              driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
+              url: "jdbc:%{hiera('wso2::rdbms::engine')}://%{hiera('wso2::rdbms::hostname')}:%{hiera('wso2::rdbms::port')}/WSO2_ANALYTICS_PROCESSED_DATA_STORE_DB?autoReconnect=true&amp;useSSL=false"
+              username: "%{hiera('wso2::datasources::mysql::username')}"
+              password: "%{hiera('wso2::datasources::mysql::password')}"
+              max_active: "%{hiera('wso2::datasources::common::max_active')}"
+              max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
+              test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
+              default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
+              validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
+              validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
+              default_auto_commit: false
+              initial_size: 0
+              test_while_idle: true
+              min_evictable_idle_time_millis: 4000
+            
+         # Analytics processed data store datasource configuration in repository/conf/analytics/analytics-config.xml
+         wso2::analytics_processed_data_store_datasource: analytics_processed_data_store_ds
+        ```
 4. Configure a clustering scheme for minimum HA deployment
  
-    In default Hiera configurations clustering is disabled. If you need to do a minimum HA deployment of WSO2 
-    Identity Server Analytics rather than a single node deployment you will have to enable clustering. 
-    For that, set ```enable``` property under ```wso2::clustering``` to ```truee```. Then, configure a clustering 
-    scheme under ```wso2::clustering```. By default, WKA related configurations are added. 
+    Configure a clustering scheme under ```wso2::clustering```. By default, WKA related configurations are added. 
     Update the member list under WKA scheme in [default.yaml](default.yaml) file with the ip addresses of the members
     participating in the cluster.
+    
     e.g:
     ```
     wso2::clustering:
@@ -131,33 +156,9 @@ Follow the given steps below, to configure hiera YAML with respect to the deploy
          hostname: 192.168.48.195
          port: 4000
     ```
-5. Enable Spark cluster for minimum HA deployment
 
-    In default Hiera configurations spark clustering is disabled. If you need to do a minimum HA deployment of WSO2 
-    Identity Server Analytics rather than a single node deployment you will have to enable spark clustering.
-    For two node spark cluster set ```master_count``` under ```wso2::spark``` to ```2```. 
-    Then, set ```enabled``` property under ```wso2::ha_deployment``` to ```true```.
-    e.g:
-    ```
-    wso2::spark:
-      master: local
-      master_count: 2
-      hostname: "%{::ipaddress}"
-    
-    wso2::ha_deployment:
-      enabled: true
-      eventSync:
-        hostName: "%{::ipaddress}"
-        port: 11224
-      management:
-        hostName: "%{::ipaddress}"
-        port: 10005
-      presentation:
-        hostName: "%{::ipaddress}"
-        port: 11002
-    ```
-    
-6. In the puppet agent set below factor variables as explained in [wiki](https://github.com/wso2/puppet-base/wiki/Use-WSO2-Puppet-Modules-in-puppet-master-agent-Environment#task-3---set-facter-variables-and-perform-a-puppet-agent-run), 
+5. In the puppet agent set below factor variables as explained in
+ [wiki](https://github.com/wso2/puppet-base/wiki/Use-WSO2-Puppet-Modules-in-puppet-master-agent-Environment#task-3---set-facter-variables-and-perform-a-puppet-agent-run), 
 and run puppet agent
     ```
     product_name=wso2is_analytics

--- a/wso2is_analytics/hieradata/dev/wso2/wso2is_analytics/pattern-1/default.yaml
+++ b/wso2is_analytics/hieradata/dev/wso2/wso2is_analytics/pattern-1/default.yaml
@@ -53,7 +53,7 @@ wso2::file_list:
 # Clustering configuration related properties of the product in repository/conf/axis2/axis2.xml
 # Clustering scheme can be wka, aws, kubenetes, mesos
 wso2::clustering:
-  enabled: false
+  enabled: true
   domain: is.analytics.wso2.domain
   local_member_host: "%{::ipaddress}"
   local_member_port: 4000
@@ -195,22 +195,19 @@ wso2::registry_mounts:
     target_path: /_system/governance
     overwrite: true
 
-wso2::spark:
-  master: local
-  master_count: 1
-  hostname: "%{::ipaddress}"
-
+# HA deployment configurations in repository/conf/event-processor.xml
 wso2::ha_deployment:
-  enabled: false
+  enabled: true
   eventSync:
     hostName: "%{::ipaddress}"
-    port: 11224
   management:
     hostName: "%{::ipaddress}"
-    port: 10005
   presentation:
     hostName: "%{::ipaddress}"
-    port: 11002
+
+# Spark configurations in repository/conf/analytics/spark/spark-defaults.conf
+wso2::spark:
+  hostname: "%{::ipaddress}"
 
 ## Secure vault configuration
 # wso2::enable_secure_vault: true

--- a/wso2is_analytics/hieradata/dev/wso2/wso2is_analytics/pattern-1/default.yaml
+++ b/wso2is_analytics/hieradata/dev/wso2/wso2is_analytics/pattern-1/default.yaml
@@ -101,11 +101,29 @@ wso2::master_datasources:
 
 # Datasource configuration related properties in repository/conf/datasources/analytics-datasources.xml
 wso2::analytics_datasources:
-  analytics_store_ds:
-    name: WSO2_ANALYTICS_STORE_DS
+  analytics_event_store_ds:
+    name: WSO2_ANALYTICS_EVENT_STORE_DS
     description: The datasource used for analytics record store
     driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
-    url: "jdbc:%{hiera('wso2::rdbms::engine')}://%{hiera('wso2::rdbms::hostname')}:%{hiera('wso2::rdbms::port')}/WSO2_ANALYTICS_DB?autoReconnect=true&amp;useSSL=false"
+    url: "jdbc:%{hiera('wso2::rdbms::engine')}://%{hiera('wso2::rdbms::hostname')}:%{hiera('wso2::rdbms::port')}/WSO2_ANALYTICS_EVENT_STORE_DB?autoReconnect=true&amp;useSSL=false"
+    username: "%{hiera('wso2::datasources::mysql::username')}"
+    password: "%{hiera('wso2::datasources::mysql::password')}"
+    max_active: "%{hiera('wso2::datasources::common::max_active')}"
+    max_wait: "%{hiera('wso2::datasources::common::max_wait')}"
+    test_on_borrow: "%{hiera('wso2::datasources::common::test_on_borrow')}"
+    default_auto_commit: "%{hiera('wso2::datasources::common::default_auto_commit')}"
+    validation_query: "%{hiera('wso2::datasources::mysql::validation_query')}"
+    validation_interval: "%{hiera('wso2::datasources::common::validation_interval')}"
+    default_auto_commit: false
+    initial_size: 0
+    test_while_idle: true
+    min_evictable_idle_time_millis: 4000
+
+  analytics_processed_data_store_ds:
+    name: WSO2_ANALYTICS_PROCESSED_DATA_STORE_DS
+    description: The datasource used for analytics record store
+    driver_class_name: "%{hiera('wso2::datasources::mysql::driver_class_name')}"
+    url: "jdbc:%{hiera('wso2::rdbms::engine')}://%{hiera('wso2::rdbms::hostname')}:%{hiera('wso2::rdbms::port')}/WSO2_ANALYTICS_PROCESSED_DATA_STORE_DB?autoReconnect=true&amp;useSSL=false"
     username: "%{hiera('wso2::datasources::mysql::username')}"
     password: "%{hiera('wso2::datasources::mysql::password')}"
     max_active: "%{hiera('wso2::datasources::common::max_active')}"
@@ -146,10 +164,10 @@ wso2::user_management:
   datasource: analytics_ds
 
 # Analytics event store datasource configuration in repository/conf/analytics/analytics-config.xml
-wso2::analytics_event_store_datasource: analytics_store_ds
+wso2::analytics_event_store_datasource: analytics_event_store_ds
 
 # Analytics processed data store datasource configuration in repository/conf/analytics/analytics-config.xml
-wso2::analytics_processed_data_store_datasource: analytics_store_ds
+wso2::analytics_processed_data_store_datasource: analytics_processed_data_store_ds
 
 # Metrics datasource configuration in repository/conf/metrics.xml
 wso2::metrics_datasource: metrics_ds

--- a/wso2is_analytics/templates/bin/load-spark-env-vars.sh.erb
+++ b/wso2is_analytics/templates/bin/load-spark-env-vars.sh.erb
@@ -20,11 +20,10 @@
 # -----------------------------------------------------------------------------
 
 echo 'Loading spark environment variables '
-export SPARK_LOCAL_IP=$HOST
+export SPARK_LOCAL_IP=<%= @ipaddress %>
 export CARBON_SPARK_HOME=$CARBON_HOME
 export _SPARK_ASSEMBLY=$CARBON_SPARK_HOME/repository/components/plugins/spark-core_2.10_*.wso2*.jar
 export SPARK_SCALA_VERSION=2.10
-export SPARK_LOCAL_IP=<%= @ipaddress %>
 # *** jars will be added to the spark classpath in the code itself. check DAS-105
 # export SPARK_CLASSPATH=`java -cp $CARBON_SPARK_HOME/repository/components/plugins/org.wso2.carbon.analytics.spark.utils*.jar org.wso2.carbon.analytics.spark.utils.ComputeClasspath $CARBON_HOME`
 # export SPARK_CLASSPATH=$SPARK_CLASSPATH:$(echo $CARBON_SPARK_HOME/repository/components/lib/*.jar | tr ' ' ':')

--- a/wso2is_analytics/templates/repository/conf/analytics/spark/spark-defaults.conf.erb
+++ b/wso2is_analytics/templates/repository/conf/analytics/spark/spark-defaults.conf.erb
@@ -34,19 +34,20 @@
 #   3. cluster mode - DAS creates its own Spark cluster usign Carbon Clustering
 #       ex: "carbon.spark.master local" AND "carbon.spark.master.count  <number of redundant masters>"
 
-carbon.spark.master <%= @spark['master'] %>
-carbon.spark.master.count  <%= @spark['master_count'] %>
+<%- if @clustering['enabled'] and @ha_deployment['enabled'] -%>
+carbon.spark.master carbon
+carbon.spark.master.count 2
+<%- else -%>
+carbon.spark.master local
+carbon.spark.master.count 1
+<%- end -%>
 
 #This configuration is used to limit the number of results returned from spark query execution
 #To return all the results, set this to -1
 carbon.spark.results.limit 1000
 
 # this configuratoin can be used to point to a symbolic link to WSO2 DAS HOME
-<%- if @clustering['enabled'] -%>
-carbon.das.symbolic.link <%= @carbon_home_symlink %>
-<%- else -%>
 # carbon.das.symbolic.link /home/ubuntu/das/das_symlink/
-<%- end -%>
 
 # this configuration can be used with the spark fair scheduler, when fair schedule pools are used. the
 #     defualt pool name for carbon is 'carbon-pool'

--- a/wso2is_analytics/templates/repository/conf/event-processor.xml.erb
+++ b/wso2is_analytics/templates/repository/conf/event-processor.xml.erb
@@ -27,7 +27,7 @@
         <checkMemberUpdateInterval>10000</checkMemberUpdateInterval>
         <eventSync>
             <hostName><%= @ha_deployment['eventSync']['hostName'] %></hostName>
-            <port><%= @ha_deployment['eventSync']['port'] %></port>
+            <port>11224</port>
             <reconnectionInterval>20000</reconnectionInterval>
             <serverThreads>20000</serverThreads>
             <!--Size of TCP event publishing client's send buffer in bytes-->
@@ -47,13 +47,13 @@
         </eventSync>
         <management>
             <hostName><%= @ha_deployment['management']['hostName'] %></hostName>
-            <port><%= @ha_deployment['management']['port'] %></port>
+            <port>10005</port>
             <tryStateChangeInterval>15000</tryStateChangeInterval>
             <stateSyncRetryInterval>10000</stateSyncRetryInterval>
         </management>
         <presentation>
             <hostName><%= @ha_deployment['presentation']['hostName'] %></hostName>
-            <port><%= @ha_deployment['presentation']['port'] %></port>
+            <port>11000</port>
             <!--Size of TCP event publishing client's send buffer in bytes-->
             <publisherTcpSendBufferSize>5242880</publisherTcpSendBufferSize>
             <!--Character encoding of TCP event publishing client-->


### PR DESCRIPTION
## Purpose
Resolves #37

## Goals
Update wso2is_analytics module for minimum HA deployment

## Approach
- Add datasources for event store and processed data store
- Enable clustering and ha deployment
- Removed unnecessary hiera entries
- Update readmes accordingly

## Test environment
JDK 8
Ubuntu 14.04
Puppet 3.8.7
Tested in puppet master agent setup