### PR TITLE
Add Initial Puppet 5 modules for WSO2 IS 5.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Puppet Modules for WSO2 Identity Server
+
+## Quick Start Guide
+1. Download and copy the wso2is-linux-installer-x64-5.6.0.deb or wso2is-linux-installer-x64-5.6.0.rpm to the files folder in /etc/puppet/code/environments/modules/wso2is/files in the Puppetmaster.
+
+2. Run the following commands in the Puppet agent
+
+```
+export FACTER_product_name=wso2is
+
+puppet agent -vt
+```

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,0 +1,31 @@
+#----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either excustomss or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#----------------------------------------------------------------------------
+
+# Run stages
+stage { 'final': }
+stage { 'custom': }
+# Order of stages
+Stage['main'] -> Stage['custom'] -> Stage['final']
+
+node "default" {
+  class { "::${::product_name}": }
+  class { "::${::product_name}::custom":
+    stage => 'custom'
+  }
+  class { "::${::product_name}::startserver":
+    stage => 'final'
+  }
+}

--- a/modules/wso2is/manifests/custom.pp
+++ b/modules/wso2is/manifests/custom.pp
@@ -1,0 +1,20 @@
+#----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#----------------------------------------------------------------------------
+
+#For custom configurations
+class wso2is::custom {
+
+}

--- a/modules/wso2is/manifests/init.pp
+++ b/modules/wso2is/manifests/init.pp
@@ -1,0 +1,92 @@
+class wso2is (
+  $wso2_user        = 'ubuntu',
+  $wso2_group       = 'ubuntu',
+  $service_name     = 'wso2is',
+  $install_path     = '/usr/lib/wso2/wso2is/5.6.0',
+
+  # Master Datasources
+  $wso2_carbon_db   = $wso2is::params::wso2_carbon_db,
+  $wso2_reg_db      = $wso2is::params::wso2_reg_db,
+  $wso2_user_db     = $wso2is::params::wso2_user_db,
+  $wso2_identity_db = $wso2is::params::wso2_identity_db,
+  $wso2_consent_db  = $wso2is::params::wso2_consent_db,
+
+  $ports            = $wso2is::params::ports,
+  $hostname         = $wso2is::params::hostname,
+  $mgt_hostname     = $wso2is::params::mgt_hostname
+
+)
+
+  inherits wso2is::params {
+
+  # Checking for the OS family
+  if $::osfamily == 'redhat' {
+    $wso2is_package = 'wso2is-linux-installer-x64-5.6.0.rpm'
+    $install_provider = 'rpm'
+  }
+  elsif $::osfamily == 'debian' {
+    $wso2is_package = 'wso2is-linux-installer-x64-5.6.0.deb'
+    $install_provider = 'dpkg'
+  }
+
+  # Ensure /opt/wso2is directory is available
+  file { '/opt/wso2is':
+    ensure => directory,
+    owner  => $wso2_user,
+    group  => $wso2_group,
+  }
+
+  # Copy the relevant installer to the /opt/wso2is directory
+  file { "/opt/wso2is/$wso2is_package":
+    mode   => "0644",
+    owner  => $wso2_user,
+    group  => $wso2_group,
+    source => "puppet:///modules/wso2is/$wso2is_package",
+  }
+
+  # Install WSO2 Identity Server
+  package { "wso2is":
+    provider => "$install_provider",
+    ensure   => installed,
+    source   => "/opt/wso2is/$wso2is_package"
+  }
+
+  # Define the template list
+  $template_list = [
+    #	'repository/conf/identity/identity.xml',
+    #	'repository/conf/carbon.xml',
+    #	'repository/conf/user-mgt.xml',
+    'repository/conf/datasources/master-datasources.xml',
+    'bin/wso2server.sh',
+    #	'repository/conf/axis2/axis2.xml',
+  ]
+
+  # Copy configuration changes to the installed directory
+  $template_list.each |String $template| {
+    file { "${install_path}/${template}":
+      ensure  => file,
+      owner   => $wso2_user,
+      group   => $wso2_group,
+      mode    => '0754',
+      content => template("wso2is/${template}.erb")
+    }
+  }
+
+  # Copy the service file with start|stop|restart|status options
+  file { "/etc/init.d/${service_name}":
+    ensure  => present,
+    owner   => root,
+    group   => root,
+    mode    => '0755',
+    content => template("wso2is/${service_name}.erb"),
+  }
+
+  # Copy the Unit file required to deploy the server as a service
+  file { "/etc/systemd/system/wso2is.service":
+    ensure  => present,
+    owner   => root,
+    group   => root,
+    mode    => '0755',
+    content => template("wso2is/wso2is.service.erb"),
+  }
+}

--- a/modules/wso2is/manifests/params.pp
+++ b/modules/wso2is/manifests/params.pp
@@ -1,0 +1,104 @@
+#----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#----------------------------------------------------------------------------
+
+class wso2is::params {
+
+  $hostname = 'localhost'
+  $mgt_hostname = 'localhost'
+
+  # Master-datasources
+  $wso2_carbon_db = {
+    name                => 'WSO2_CARBON_DB',
+    description         => 'The datasource used for registry and user manager',
+    driver_class_name   => 'org.h2.Driver',
+    url                 => 'jdbc:h2:repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000',
+    username            => 'wso2carbon',
+    password            => 'wso2carbon',
+    jndi_config         => 'jdbc/WSO2CarbonDB',
+    max_active          => '50',
+    max_wait            => '60000',
+    test_on_borrow      => true,
+    default_auto_commit => false,
+    validation_query    => 'SELECT 1',
+    validation_interval => '30000'
+  }
+  $wso2_reg_db = {
+    name                => 'WSO2_REG_DB',
+    description         => 'The datasource used for registry',
+    driver_class_name   => 'org.h2.Driver',
+    url                 => 'jdbc:h2:repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000',
+    username            => 'wso2carbon',
+    password            => 'wso2carbon',
+    jndi_config         => 'jdbc/WSO2RegDS',
+    max_active          => '50',
+    max_wait            => '60000',
+    test_on_borrow      => true,
+    default_auto_commit => false,
+    validation_query    => 'SELECT 1',
+    validation_interval => '30000'
+  }
+  $wso2_user_db = {
+    name                => 'WSO2_USER_DB',
+    description         => 'The datasource used for user management',
+    driver_class_name   => 'org.h2.Driver',
+    url                 => 'jdbc:h2:repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000',
+    username            => 'wso2carbon',
+    password            => 'wso2carbon',
+    jndi_config         => 'jdbc/WSO2UserDS',
+    max_active          => '50',
+    max_wait            => '60000',
+    test_on_borrow      => true,
+    default_auto_commit => false,
+    validation_query    => 'SELECT 1',
+    validation_interval => '30000'
+  }
+  $wso2_identity_db = {
+    name                => 'WSO2_IDENTITY_DB',
+    description         => 'The datasource used for identity management',
+    driver_class_name   => 'org.h2.Driver',
+    url                 => 'jdbc:h2:repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000',
+    username            => 'wso2carbon',
+    password            => 'wso2carbon',
+    jndi_config         => 'jdbc/WSO2IdentityDS',
+    max_active          => '50',
+    max_wait            => '60000',
+    test_on_borrow      => true,
+    default_auto_commit => false,
+    validation_query    => 'SELECT 1',
+    validation_interval => '30000'
+  }
+
+  $wso2_consent_db = {
+    name                => 'WSO2_CONSENT_DB',
+    description         => 'The datasource used for registry and user manager',
+    driver_class_name   => 'org.h2.Driver',
+    url                 => 'jdbc:h2:repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000',
+    username            => 'wso2carbon',
+    password            => 'wso2carbon',
+    jndi_config         => 'jdbc/WSO2ConsentDS',
+    max_active          => '50',
+    max_wait            => '60000',
+    test_on_borrow      => true,
+    default_auto_commit => false,
+    validation_query    => 'SELECT 1',
+    validation_interval => '30000'
+  }
+
+  $ports = {
+    offset => 0
+  }
+
+}

--- a/modules/wso2is/manifests/startserver.pp
+++ b/modules/wso2is/manifests/startserver.pp
@@ -1,0 +1,15 @@
+class wso2is::start {
+
+  $install_path = '/usr/lib/wso2/wso2is/5.6.0'
+
+  exec { 'systemctl daemon-reload':
+    command => "systemctl daemon-reload",
+    cwd     => "${install_path}/bin",
+    path    => '/usr/bin:/usr/sbin:/bin',
+  }
+
+  service { 'wso2is':
+    enable => true,
+    ensure => running,
+  }
+}

--- a/modules/wso2is/templates/bin/wso2server.sh.erb
+++ b/modules/wso2is/templates/bin/wso2server.sh.erb
@@ -1,0 +1,319 @@
+#!/bin/sh
+#----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#----------------------------------------------------------------------------
+# Main Script for the WSO2 Carbon Server
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of WSO2 Carbon installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+#   JAVA_OPTS       (Optional) Java runtime options used when the commands
+#                   is executed.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+# -----------------------------------------------------------------------------
+
+# OS specific support.  $var _must_ be set to either true or false.
+#ulimit -n 100000
+
+JAVA_HOME="<%=@install_path%>/jre/jre1.8.0_172";
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# Set AXIS2_HOME. Needed for One Click JAR Download
+AXIS2_HOME="$CARBON_HOME"
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$AXIS2_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+if [ -e "$CARBON_HOME/wso2carbon.pid" ]; then
+  PID=`cat "$CARBON_HOME"/wso2carbon.pid`
+fi
+
+# ----- Process the input command ----------------------------------------------
+args=""
+for c in $*
+do
+    if [ "$c" = "--debug" ] || [ "$c" = "-debug" ] || [ "$c" = "debug" ]; then
+          CMD="--debug"
+          continue
+    elif [ "$CMD" = "--debug" ]; then
+          if [ -z "$PORT" ]; then
+                PORT=$c
+          fi
+    elif [ "$c" = "--stop" ] || [ "$c" = "-stop" ] || [ "$c" = "stop" ]; then
+          CMD="stop"
+    elif [ "$c" = "--start" ] || [ "$c" = "-start" ] || [ "$c" = "start" ]; then
+          CMD="start"
+    elif [ "$c" = "--version" ] || [ "$c" = "-version" ] || [ "$c" = "version" ]; then
+          CMD="version"
+    elif [ "$c" = "--restart" ] || [ "$c" = "-restart" ] || [ "$c" = "restart" ]; then
+          CMD="restart"
+    elif [ "$c" = "--test" ] || [ "$c" = "-test" ] || [ "$c" = "test" ]; then
+          CMD="test"
+    else
+        args="$args $c"
+    fi
+done
+
+if [ "$CMD" = "--debug" ]; then
+  if [ "$PORT" = "" ]; then
+    echo " Please specify the debug port after the --debug option"
+    exit 1
+  fi
+  if [ -n "$JAVA_OPTS" ]; then
+    echo "Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option."
+  fi
+  CMD="RUN"
+  JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
+  echo "Please start the remote debugging client to continue..."
+elif [ "$CMD" = "start" ]; then
+  if [ -e "$CARBON_HOME/wso2carbon.pid" ]; then
+    if  ps -p $PID > /dev/null ; then
+      echo "Process is already running"
+      exit 0
+    fi
+  fi
+  export CARBON_HOME="$CARBON_HOME"
+# using nohup sh to avoid erros in solaris OS.TODO
+  nohup sh "$CARBON_HOME"/bin/wso2server.sh $args > /dev/null 2>&1 &
+  exit 0
+elif [ "$CMD" = "stop" ]; then
+  export CARBON_HOME="$CARBON_HOME"
+  kill -term `cat "$CARBON_HOME"/wso2carbon.pid`
+  exit 0
+elif [ "$CMD" = "restart" ]; then
+  export CARBON_HOME="$CARBON_HOME"
+  kill -term `cat "$CARBON_HOME"/wso2carbon.pid`
+  process_status=0
+  pid=`cat "$CARBON_HOME"/wso2carbon.pid`
+  while [ "$process_status" -eq "0" ]
+  do
+        sleep 1;
+        ps -p$pid 2>&1 > /dev/null
+        process_status=$?
+  done
+
+# using nohup sh to avoid erros in solaris OS.TODO
+  nohup sh "$CARBON_HOME"/bin/wso2server.sh $args > /dev/null 2>&1 &
+  exit 0
+elif [ "$CMD" = "test" ]; then
+    JAVACMD="exec "$JAVACMD""
+elif [ "$CMD" = "version" ]; then
+  cat "$CARBON_HOME"/bin/version.txt
+  cat "$CARBON_HOME"/bin/wso2carbon-version.txt
+  exit 0
+fi
+
+# ---------- Handle the SSL Issue with proper JDK version --------------------
+jdk_17=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[7|8]"`
+if [ "$jdk_17" = "" ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.7 and 1.8"
+fi
+
+CARBON_XBOOTCLASSPATH=""
+for f in "$CARBON_HOME"/lib/xboot/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/lib/xboot/*.jar" ];then
+        CARBON_XBOOTCLASSPATH="$CARBON_XBOOTCLASSPATH":$f
+    fi
+done
+
+JAVA_ENDORSED_DIRS="$CARBON_HOME/lib/endorsed":"$JAVA_HOME/jre/lib/endorsed":"$JAVA_HOME/lib/endorsed"
+
+CARBON_CLASSPATH=""
+if [ -e "$JAVA_HOME/lib/tools.jar" ]; then
+    CARBON_CLASSPATH="$JAVA_HOME/lib/tools.jar"
+fi
+for f in "$CARBON_HOME"/bin/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/bin/*.jar" ];then
+        CARBON_CLASSPATH="$CARBON_CLASSPATH":$f
+    fi
+done
+for t in "$CARBON_HOME"/lib/commons-lang*.jar
+do
+    CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
+done
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  AXIS2_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  CARBON_CLASSPATH=`cygpath --path --windows "$CARBON_CLASSPATH"`
+  CARBON_XBOOTCLASSPATH=`cygpath --path --windows "$CARBON_XBOOTCLASSPATH"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to "$CARBON_HOME"
+
+cd "$CARBON_HOME"
+
+TMP_DIR="$CARBON_HOME"/tmp
+if [ -d "$TMP_DIR" ]; then
+rm -rf "$TMP_DIR"/*
+fi
+
+START_EXIT_STATUS=121
+status=$START_EXIT_STATUS
+
+if [ -z "$JVM_MEM_OPTS" ]; then
+   java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+   JVM_MEM_OPTS="-Xms256m -Xmx1024m"
+   if [ "$java_version" \< "1.8" ]; then
+      JVM_MEM_OPTS="$JVM_MEM_OPTS -XX:MaxPermSize=256m"
+   fi
+fi
+echo "Using Java memory options: $JVM_MEM_OPTS"
+
+#To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
+#   -Djava.rmi.server.hostname="your.IP.goes.here"
+
+while [ "$status" = "$START_EXIT_STATUS" ]
+do
+    $JAVACMD \
+    -Xbootclasspath/a:"$CARBON_XBOOTCLASSPATH" \
+    $JVM_MEM_OPTS \
+    -XX:+HeapDumpOnOutOfMemoryError \
+    -XX:HeapDumpPath="$CARBON_HOME/repository/logs/heap-dump.hprof" \
+    $JAVA_OPTS \
+    -Dcom.sun.management.jmxremote \
+    -classpath "$CARBON_CLASSPATH" \
+    -Djava.endorsed.dirs="$JAVA_ENDORSED_DIRS" \
+    -Djava.io.tmpdir="$CARBON_HOME/tmp" \
+    -Dcatalina.base="$CARBON_HOME/lib/tomcat" \
+    -Dwso2.server.standalone=true \
+    -Dcarbon.registry.root=/ \
+    -Djava.command="$JAVACMD" \
+    -Dcarbon.home="$CARBON_HOME" \
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager \
+    -Dcarbon.config.dir.path="$CARBON_HOME/repository/conf" \
+    -Djava.util.logging.config.file="$CARBON_HOME/repository/conf/etc/logging-bridge.properties" \
+    -Dcomponents.repo="$CARBON_HOME/repository/components/plugins" \
+    -Dconf.location="$CARBON_HOME/repository/conf"\
+    -Dcom.atomikos.icatch.file="$CARBON_HOME/lib/transactions.properties" \
+    -Dcom.atomikos.icatch.hide_init_file_path=true \
+    -Dorg.apache.jasper.compiler.Parser.STRICT_QUOTE_ESCAPING=false \
+    -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true \
+    -Dcom.sun.jndi.ldap.connect.pool.authentication=simple  \
+    -Dcom.sun.jndi.ldap.connect.pool.timeout=3000  \
+    -Dorg.terracotta.quartz.skipUpdateCheck=true \
+    -Djava.security.egd=file:/dev/./urandom \
+    -Dfile.encoding=UTF8 \
+    -Djava.net.preferIPv4Stack=true \
+    -Dcom.ibm.cacheLocalHost=true \
+    -DworkerNode=false \
+    -Dhttpclient.hostnameVerifier="DefaultAndLocalhost" \
+    org.wso2.carbon.bootstrap.Bootstrap $*
+    status=$?
+done

--- a/modules/wso2is/templates/repository/conf/axis2/axis2.xml.erb
+++ b/modules/wso2is/templates/repository/conf/axis2/axis2.xml.erb
@@ -1,0 +1,1466 @@
+<!--
+
+  ~ Copyright 2005-2011 WSO2, Inc. (http://wso2.com)
+
+  ~
+
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+
+  ~ you may not use this file except in compliance with the License.
+
+  ~ You may obtain a copy of the License at
+
+  ~
+
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+
+  ~
+
+  ~ Unless required by applicable law or agreed to in writing, software
+
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+  ~ See the License for the specific language governing permissions and
+
+  ~ limitations under the License.
+
+  -->
+
+
+
+<axisconfig name="AxisJava2.0">
+
+
+
+    <!-- ================================================= -->
+
+    <!-- Globally engaged modules -->
+
+    <!-- ================================================= -->
+
+    <module ref="addressing"/>
+
+
+
+    <!-- ================================================= -->
+
+    <!-- Parameters -->
+
+    <!-- ================================================= -->
+
+    <parameter name="hotdeployment">true</parameter>
+
+    <parameter name="hotupdate">true</parameter>
+
+    <parameter name="enableMTOM" locked="false">optional</parameter>
+
+    <parameter name="cacheAttachments">true</parameter>
+
+    <parameter name="attachmentDIR">work/mtom</parameter>
+
+    <parameter name="sizeThreshold">4000</parameter>
+
+
+
+    <parameter name="EnableChildFirstClassLoading">${childfirstCL}</parameter>
+
+
+
+    <!--
+
+    The exposeServiceMetadata parameter decides whether the metadata (WSDL, schema, policy) of
+
+    the services deployed on Axis2 should be visible when ?wsdl, ?wsdl2, ?xsd, ?policy requests
+
+    are received.
+
+    This parameter can be defined in the axi2.xml file, in which case this will be applicable
+
+    globally, or in the services.xml files, in which case, it will be applicable to the
+
+    Service groups and/or services, depending on the level at which the parameter is declared.
+
+    This value of this parameter defaults to true.
+
+    -->
+
+    <parameter name="exposeServiceMetadata">true</parameter>
+
+
+
+    <!--If turned on with use the Accept header of the request to determine the contentType of the
+
+    response-->
+
+    <parameter name="httpContentNegotiation">true</parameter>
+
+
+
+    <!--
+
+    Defines how the persistence of WS-ReliableMessaging is handled
+
+
+
+    Possible value are: inmemory & persistent
+
+    -->
+
+    <!-- Following parameter will completely disable REST handling in both the servlets-->
+
+    <parameter name="disableREST" locked="false">false</parameter>
+
+
+
+    <parameter name="Sandesha2StorageManager">inmemory</parameter>
+
+
+
+    <!-- This deployment interceptor will be called whenever before a module is initialized or
+
+     service is deployed -->
+
+    <listener class="org.wso2.carbon.core.deployment.DeploymentInterceptor"/>
+
+
+
+    <!-- setting servicePath. contextRoot is defined in the carbon.xml file -->
+
+    <!-- modification of this variable should be accompanied by the change in 'ServerURL' in carbon.xml file -->
+
+    <parameter name="servicePath">services</parameter>
+
+
+
+    <!--the directory in which .aar services are deployed inside axis2 repository-->
+
+    <parameter name="ServicesDirectory">axis2services</parameter>
+
+
+
+    <!--the directory in which modules are deployed inside axis2 repository-->
+
+    <parameter name="ModulesDirectory">axis2modules</parameter>
+
+
+
+    <parameter name="userAgent" locked="true">
+
+        WSO2 Identity Server-5.6.0
+
+    </parameter>
+
+    <parameter name="server" locked="true">
+
+        WSO2 Identity Server-5.6.0
+
+    </parameter>
+
+
+
+    <!-- ========================================================================-->
+
+
+
+    <!--During a fault, stacktrace can be sent with the fault message. The following flag will control -->
+
+    <!--that behaviour.-->
+
+    <parameter name="sendStacktraceDetailsWithFaults">false</parameter>
+
+
+
+    <!--If there aren't any information available to find out the fault reason, we set the message of the expcetion-->
+
+    <!--as the faultreason/Reason. But when a fault is thrown from a service or some where, it will be -->
+
+    <!--wrapped by different levels. Due to this the initial exception message can be lost. If this flag-->
+
+    <!--is set then, Axis2 tries to get the first exception and set its message as the faultreason/Reason.-->
+
+    <parameter name="DrillDownToRootCauseForFaultReason">false</parameter>
+
+
+
+    <!--Set the flag to true if you want to enable transport level session mangment-->
+
+    <parameter name="manageTransportSession">true</parameter>
+
+
+
+    <!-- Synapse Configuration file -->
+
+    <parameter name="SynapseConfig.ConfigurationFile" locked="false">
+
+        ./repository/deployment/server/synapse-configs
+
+    </parameter>
+
+
+
+    <!-- Synapse Home parameter -->
+
+    <parameter name="SynapseConfig.HomeDirectory" locked="false">.</parameter>
+
+
+
+    <!-- Resolve root used to resolve synapse references like schemas inside a WSDL -->
+
+    <parameter name="SynapseConfig.ResolveRoot" locked="false">.</parameter>
+
+
+
+    <!-- Synapse Server name parameter -->
+
+    <parameter name="SynapseConfig.ServerName" locked="false">WSO2 Carbon Server</parameter>
+
+
+
+    <!--By default, JAXWS services are created by reading annotations. WSDL and schema are generated-->
+
+    <!--using a separate WSDL generator only when ?wsdl is called. Therefore, even if you engage-->
+
+    <!--policies etc.. to AxisService, it doesn't appear in the WSDL. By setting the following property-->
+
+    <!--to true, you can create the AxisService using the generated WSDL and remove the need for a-->
+
+    <!--WSDL generator. When ?wsdl is called, WSDL is generated in the normal way.-->
+
+    <parameter name="useGeneratedWSDLinJAXWS">${jaxwsparam}</parameter>
+
+
+
+    <!-- Deployer for the dataservice. -->
+
+    <!--<deployer extension="dbs" directory="dataservices" class="org.wso2.dataservices.DBDeployer"/>-->
+
+
+
+    <!-- Axis1 deployer for Axis2-->
+
+    <!--<deployer extension="wsdd" class="org.wso2.carbon.axis1services.Axis1Deployer" directory="axis1services"/>-->
+
+
+
+    <!-- POJO service deployer for Jar -->
+
+    <!--<deployer extension="jar" class="org.apache.axis2.deployment.POJODeployer" directory="pojoservices"/>-->
+
+
+
+    <!-- POJO service deployer for Class  -->
+
+    <!--<deployer extension="class" class="org.apache.axis2.deployment.POJODeployer" directory="pojoservices"/>-->
+
+
+
+    <!-- JAXWS service deployer  -->
+
+    <!--<deployer extension=".jar" class="org.apache.axis2.jaxws.framework.JAXWSDeployer" directory="servicejars"/>-->
+
+    <!-- ================================================= -->
+
+    <!-- Message Receivers -->
+
+    <!-- ================================================= -->
+
+    <!--This is the Default Message Receiver for the system , if you want to have MessageReceivers for -->
+
+    <!--all the other MEP implement it and add the correct entry to here , so that you can refer from-->
+
+    <!--any operation -->
+
+    <!--Note : You can ovride this for particular service by adding the same element with your requirement-->
+
+
+
+    <messageReceivers>
+
+        <messageReceiver mep="http://www.w3.org/ns/wsdl/in-only"
+
+                         class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
+
+        <messageReceiver mep="http://www.w3.org/ns/wsdl/robust-in-only"
+
+                         class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
+
+        <messageReceiver mep="http://www.w3.org/ns/wsdl/in-out"
+
+                         class="org.apache.axis2.rpc.receivers.RPCMessageReceiver"/>
+
+    </messageReceivers>
+
+
+
+    <messageFormatters>
+
+        <messageFormatter contentType="application/x-www-form-urlencoded"
+
+                          class="org.apache.axis2.transport.http.XFormURLEncodedFormatter"/>
+
+        <messageFormatter contentType="multipart/form-data"
+
+                          class="org.apache.axis2.transport.http.MultipartFormDataFormatter"/>
+
+        <messageFormatter contentType="application/xml"
+
+                          class="org.apache.axis2.transport.http.ApplicationXMLFormatter"/>
+
+        <messageFormatter contentType="text/xml"
+
+                          class="org.apache.axis2.transport.http.SOAPMessageFormatter"/>
+
+        <messageFormatter contentType="application/soap+xml"
+
+                          class="org.apache.axis2.transport.http.SOAPMessageFormatter"/>
+
+
+
+        <!--JSON Message Formatters-->
+
+        <!--messageFormatter contentType="application/json"
+
+                          class="org.apache.axis2.json.JSONMessageFormatter"/-->
+
+        <messageFormatter contentType="application/json"
+
+                                  class="org.apache.axis2.json.gson.JsonFormatter" />
+
+        <messageFormatter contentType="application/json/badgerfish"
+
+                          class="org.apache.axis2.json.JSONBadgerfishMessageFormatter"/>
+
+        <!--messageFormatter contentType="text/javascript"
+
+                          class="org.apache.axis2.json.JSONMessageFormatter"/-->
+
+        <messageFormatter contentType="text/javascript"
+
+                                  class="org.apache.axis2.json.gson.JsonFormatter" />
+
+
+
+        <!--messageFormatter contentType="application/x-www-form-urlencoded"
+
+                        class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
+
+        <!--messageFormatter contentType="multipart/form-data"
+
+                        class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
+
+        <!--messageFormatter contentType="application/xml"
+
+                        class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
+
+        <!--messageFormatter contentType="text/html"
+
+                        class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
+
+        <!--messageFormatter contentType="application/soap+xml"
+
+                        class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
+
+        <!--messageFormatter contentType="x-application/hessian"
+
+			class="org.apache.synapse.format.hessian.HessianMessageFormatter"/-->
+
+        <!--<messageFormatter contentType="">
+
+			class="org.apache.synapse.format.hessian.HessianMessageFormatter"/-->
+
+    </messageFormatters>
+
+
+
+    <messageBuilders>
+
+        <messageBuilder contentType="application/xml"
+
+                        class="org.apache.axis2.builder.ApplicationXMLBuilder"/>
+
+        <messageBuilder contentType="application/x-www-form-urlencoded"
+
+                        class="org.apache.axis2.builder.XFormURLEncodedBuilder"/>
+
+        <messageBuilder contentType="multipart/form-data"
+
+                        class="org.apache.axis2.builder.MultipartFormDataBuilder"/>
+
+
+
+        <!--JSON Message Builders-->
+
+        <!--messageBuilder contentType="application/json"
+
+                        class="org.apache.axis2.json.JSONOMBuilder"/-->
+
+        <messageBuilder contentType="application/json"
+
+                                class="org.apache.axis2.json.gson.JsonBuilder" />
+
+        <messageBuilder contentType="application/json/badgerfish"
+
+                        class="org.apache.axis2.json.JSONBadgerfishOMBuilder"/>
+
+        <!--messageBuilder contentType="text/javascript"
+
+                        class="org.apache.axis2.json.JSONOMBuilder"/-->
+
+        <messageBuilder contentType="text/javascript"
+
+                                class="org.apache.axis2.json.gson.JsonBuilder" />
+
+
+
+        <!--messageBuilder contentType="application/xml"
+
+     		        class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+
+        <!--messageBuilder contentType="application/x-www-form-urlencoded"
+
+                        class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+
+        <!--messageBuilder contentType="multipart/form-data"
+
+                        class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+
+        <!--messageBuilder contentType="multipart/related"
+
+                       class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+
+        <!--messageBuilder contentType="application/soap+xml"
+
+                       class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+
+        <!--messageBuilder contentType="text/plain"
+
+                       class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+
+        <!--messageBuilder contentType="text/xml"
+
+                       class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+
+        <!--messageFormatter contentType="text/plain"
+
+                        class="org.apache.axis2.format.PlainTextBuilder"/-->
+
+        <!--messageBuilder contentType="x-application/hessian"
+
+		       class="org.apache.synapse.format.hessian.HessianMessageBuilder"/-->
+
+    </messageBuilders>
+
+
+
+
+
+    <!-- ================================================= -->
+
+    <!-- In Transports -->
+
+    <!-- ================================================= -->
+
+    <transportReceiver name="http"
+
+                       class="org.wso2.carbon.core.transports.http.HttpTransportListener">
+
+        <!--
+
+           Uncomment the following if you are deploying this within an application server. You
+
+           need to specify the HTTP port of the application server
+
+        -->
+
+        <parameter name="port">9763</parameter>
+
+
+
+        <!--
+
+       Uncomment the following to enable any proxy like Apache2 mod_proxy or any load balancer. The port on the proxy server like Apache is 80
+
+       in this case.
+
+        -->
+
+        <!--<parameter name="proxyPort">80</parameter>-->
+
+    </transportReceiver>
+
+
+
+    <!--Please uncomment this in Multiple Instance Scenario if you want to use NIO Transport Recievers and
+
+ 	Remove the current transport REceivers in axis2.xml -->
+
+    <!--transportReceiver name="http" class="org.apache.synapse.transport.nhttp.HttpCoreNIOListener">
+
+        <parameter name="port" locked="false">8280</parameter>
+
+        <parameter name="non-blocking" locked="false">true</parameter>
+
+    </transportReceiver>
+
+
+
+    <transportReceiver name="https" class="org.apache.synapse.transport.nhttp.HttpCoreNIOSSLListener">
+
+        <parameter name="port" locked="false">8243</parameter>
+
+        <parameter name="non-blocking" locked="false">true</parameter>
+
+        <parameter name="keystore" locked="false">
+
+            <KeyStore>
+
+                <Location>repository/resources/security/wso2carbon.jks</Location>
+
+                <Type>JKS</Type>
+
+                <Password>wso2carbon</Password>
+
+                <KeyPassword>wso2carbon</KeyPassword>
+
+            </KeyStore>
+
+        </parameter>
+
+        <parameter name="truststore" locked="false">
+
+            <TrustStore>
+
+                <Location>repository/resources/security/client-truststore.jks</Location>
+
+                <Type>JKS</Type>
+
+                <Password>wso2carbon</Password>
+
+            </TrustStore>
+
+        </parameter>
+
+    </transportReceiver-->
+
+
+
+
+
+    <transportReceiver name="https"
+
+                       class="org.wso2.carbon.core.transports.http.HttpsTransportListener">
+
+        <!--
+
+           Uncomment the following if you are deploying this within an application server. You
+
+           need to specify the HTTPS port of the application server
+
+        -->
+
+        <parameter name="port">9443</parameter>
+
+
+
+        <!--
+
+       Uncomment the following to enable any proxy like Apache2 mod_proxy or any load balancer. The port on a proxy server like Apache is 443
+
+       in this case.
+
+        -->
+
+        <!--<parameter name="proxyPort">443</parameter>-->
+
+    </transportReceiver>
+
+
+
+    <!--
+
+       Uncomment the following segment to enable TCP transport.
+
+       Note : Addressing module should be engaged for TCP transport to work
+
+    -->
+
+    <!--<transportReceiver name="tcp"
+
+                       class="org.apache.axis2.transport.tcp.TCPServer">
+
+        <parameter name="port">6667</parameter>
+
+    </transportReceiver>-->
+
+
+
+    <!--
+
+     To Enable Mail Transport Listener, please uncomment the following.
+
+    -->
+
+    <!--<transportReceiver name="mailto" class="org.apache.axis2.transport.mail.MailTransportListener">
+
+
+
+    </transportReceiver>-->
+
+
+
+
+
+    <!--
+
+      Uncomment this and configure as appropriate for JMS transport support,
+
+      after setting up your JMS environment (e.g. ActiveMQ)
+
+    -->
+
+    <!--<transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
+
+        <parameter name="myTopicConnectionFactory">
+
+        	<parameter name="java.naming.factory.initial">org.apache.activemq.jndi.ActiveMQInitialContextFactory</parameter>
+
+        	<parameter name="java.naming.provider.url">tcp://localhost:61616</parameter>
+
+        	<parameter name="transport.jms.ConnectionFactoryJNDIName">TopicConnectionFactory</parameter>
+
+        </parameter>
+
+
+
+        <parameter name="myQueueConnectionFactory">
+
+        	<parameter name="java.naming.factory.initial">org.apache.activemq.jndi.ActiveMQInitialContextFactory</parameter>
+
+        	<parameter name="java.naming.provider.url">tcp://localhost:61616</parameter>
+
+        	<parameter name="transport.jms.ConnectionFactoryJNDIName">QueueConnectionFactory</parameter>
+
+        </parameter>
+
+
+
+        <parameter name="default">
+
+        	<parameter name="java.naming.factory.initial">org.apache.activemq.jndi.ActiveMQInitialContextFactory</parameter>
+
+        	<parameter name="java.naming.provider.url">tcp://localhost:61616</parameter>
+
+        	<parameter name="transport.jms.ConnectionFactoryJNDIName">QueueConnectionFactory</parameter>
+
+        </parameter>
+
+    </transportReceiver>-->
+
+
+
+    <!--Uncomment this and configure as appropriate for JMS transport support with Apache Qpid -->
+
+    <!--transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
+
+        <parameter name="myTopicConnectionFactory" locked="false">
+
+            <parameter name="java.naming.factory.initial" locked="false">org.apache.qpid.jndi.PropertiesFileInitialContextFactory</parameter>
+
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">TopicConnectionFactory</parameter>
+
+            <parameter name="transport.jms.ConnectionFactoryType" locked="false">topic</parameter>
+
+        </parameter>
+
+
+
+        <parameter name="myQueueConnectionFactory" locked="false">
+
+            <parameter name="java.naming.factory.initial" locked="false">org.apache.qpid.jndi.PropertiesFileInitialContextFactory</parameter>
+
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">QueueConnectionFactory</parameter>
+
+            <parameter name="transport.jms.ConnectionFactoryType" locked="false">queue</parameter>
+
+        </parameter>
+
+
+
+        <parameter name="default" locked="false">
+
+            <parameter name="java.naming.factory.initial" locked="false">org.apache.qpid.jndi.PropertiesFileInitialContextFactory</parameter>
+
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">QueueConnectionFactory</parameter>
+
+            <parameter name="transport.jms.ConnectionFactoryType" locked="false">queue</parameter>
+
+        </parameter>
+
+    </transportReceiver-->
+
+
+
+    <!--Uncomment this and configure as appropriate for JMS transport support with WSO2 MB 2.x.x -->
+
+    <!--transportReceiver name="jms" class="org.apache.axis2.transport.jms.JMSListener">
+
+        <parameter name="myTopicConnectionFactory" locked="false">
+
+           <parameter name="java.naming.factory.initial" locked="false">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</parameter>
+
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">TopicConnectionFactory</parameter>
+
+            <parameter name="transport.jms.ConnectionFactoryType" locked="false">topic</parameter>
+
+        </parameter>
+
+
+
+        <parameter name="myQueueConnectionFactory" locked="false">
+
+            <parameter name="java.naming.factory.initial" locked="false">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</parameter>
+
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">QueueConnectionFactory</parameter>
+
+           <parameter name="transport.jms.ConnectionFactoryType" locked="false">queue</parameter>
+
+        </parameter>
+
+
+
+        <parameter name="default" locked="false">
+
+            <parameter name="java.naming.factory.initial" locked="false">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</parameter>
+
+            <parameter name="java.naming.provider.url" locked="false">repository/conf/jndi.properties</parameter>
+
+            <parameter name="transport.jms.ConnectionFactoryJNDIName" locked="false">QueueConnectionFactory</parameter>
+
+            <parameter name="transport.jms.ConnectionFactoryType" locked="false">queue</parameter>
+
+        </parameter>
+
+    </transportReceiver-->
+
+
+
+
+
+    <!-- ================================================= -->
+
+    <!-- Out Transports -->
+
+    <!-- ================================================= -->
+
+
+
+    <!--transportSender name="tcp"
+
+                     class="org.apache.axis2.transport.tcp.TCPTransportSender"/-->
+
+    <transportReceiver name="local"
+
+                       class="org.wso2.carbon.core.transports.local.CarbonLocalTransportReceiver"/>
+
+    <transportSender name="local"
+
+                     class="org.wso2.carbon.core.transports.local.CarbonLocalTransportSender"/>
+
+    <!--<transportSender name="jms"
+
+                     class="org.apache.axis2.transport.jms.JMSSender"/>-->
+
+    <transportSender name="http"
+
+                     class="org.apache.axis2.transport.http.CommonsHTTPTransportSender">
+
+        <parameter name="PROTOCOL">HTTP/1.1</parameter>
+
+        <parameter name="Transfer-Encoding">chunked</parameter>
+
+        <!-- This parameter has been added to overcome problems encounted in SOAP action parameter -->
+
+        <parameter name="OmitSOAP12Action">true</parameter>
+
+    </transportSender>
+
+    <transportSender name="https"
+
+                     class="org.apache.axis2.transport.http.CommonsHTTPTransportSender">
+
+        <parameter name="PROTOCOL">HTTP/1.1</parameter>
+
+        <parameter name="Transfer-Encoding">chunked</parameter>
+
+        <!-- This parameter has been added to overcome problems encounted in SOAP action parameter -->
+
+        <parameter name="OmitSOAP12Action">true</parameter>
+
+    </transportSender>
+
+
+
+    <!-- To enable mail transport sender, ncomment the following and change the parameters
+
+         accordingly-->
+
+    <!--<transportSender name="mailto"
+
+                     class="org.apache.axis2.transport.mail.MailTransportSender">
+
+        <parameter name="mail.smtp.from">wso2demomail@gmail.com</parameter>
+
+        <parameter name="mail.smtp.user">wso2demomail</parameter>
+
+        <parameter name="mail.smtp.password">mailpassword</parameter>
+
+        <parameter name="mail.smtp.host">smtp.gmail.com</parameter>
+
+
+
+        <parameter name="mail.smtp.port">587</parameter>
+
+        <parameter name="mail.smtp.starttls.enable">true</parameter>
+
+        <parameter name="mail.smtp.auth">true</parameter>
+
+    </transportSender>-->
+
+
+
+    <!--Please uncomment this in Multiple Instance Scenario if you want to use NIO sender -->
+
+    <!--
+
+    <transportSender name="http" class="org.apache.synapse.transport.nhttp.HttpCoreNIOSender">
+
+        <parameter name="non-blocking" locked="false">true</parameter>
+
+    </transportSender>
+
+    <transportSender name="https" class="org.apache.synapse.transport.nhttp.HttpCoreNIOSSLSender">
+
+        <parameter name="non-blocking" locked="false">true</parameter>
+
+        <parameter name="keystore" locked="false">
+
+            <KeyStore>
+
+                <Location>repository/resources/security/wso2carbon.jks</Location>
+
+                <Type>JKS</Type>
+
+                <Password>wso2carbon</Password>
+
+                <KeyPassword>wso2carbon</KeyPassword>
+
+            </KeyStore>
+
+        </parameter>
+
+        <parameter name="truststore" locked="false">
+
+            <TrustStore>
+
+                <Location>repository/resources/security/client-truststore.jks</Location>
+
+                <Type>JKS</Type>
+
+                <Password>wso2carbon</Password>
+
+            </TrustStore>
+
+        </parameter>
+
+    </transportSender>
+
+	-->
+
+
+
+
+
+    <!-- ================================================= -->
+
+    <!-- Phases  -->
+
+    <!-- ================================================= -->
+
+    <phaseOrder type="InFlow">
+
+        <!--  System pre defined phases       -->
+
+        <!--
+
+           The MsgInObservation phase is used to observe messages as soon as they are
+
+           received. In this phase, we could do some things such as SOAP message tracing & keeping
+
+           track of the time at which a particular message was received
+
+
+
+           NOTE: This should be the very first phase in this flow
+
+        -->
+
+        <phase name="MsgInObservation"/>
+
+
+
+        <phase name="Validation"/>
+
+        <phase name="Transport">
+
+            <handler name="RequestURIBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.RequestURIBasedDispatcher">
+
+                <order phase="Transport"/>
+
+            </handler>
+
+            <handler name="SOAPActionBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.SOAPActionBasedDispatcher">
+
+                <order phase="Transport"/>
+
+            </handler>
+
+            <handler name="RequestURIOperationDispatcher"
+
+                     class="org.apache.axis2.dispatchers.RequestURIOperationDispatcher" />
+
+            <handler name="JSONMessageHandler"
+
+                     class="org.apache.axis2.json.gson.JSONMessageHandler" />
+
+        </phase>
+
+        <phase name="Addressing">
+
+            <handler name="AddressingBasedDispatcher"
+
+                     class="org.wso2.carbon.core.multitenancy.MultitenantAddressingBasedDispatcher">
+
+                <order phase="Addressing"/>
+
+            </handler>
+
+        </phase>
+
+        <phase name="Ghost">
+
+            <handler name="GhostDispatcher"
+
+                     class="org.wso2.carbon.core.dispatchers.GhostDispatcher"/>
+
+        </phase>
+
+        <phase name="Security"/>
+
+        <phase name="PreDispatch"/>
+
+        <phase name="Dispatch" class="org.apache.axis2.engine.DispatchPhase">
+
+            <handler name="RequestURIBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.RequestURIBasedDispatcher"/>
+
+            <handler name="SOAPActionBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.SOAPActionBasedDispatcher"/>
+
+            <handler name="SOAPMessageBodyBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.SOAPMessageBodyBasedDispatcher"/>
+
+
+
+            <handler name="HTTPLocationBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.HTTPLocationBasedDispatcher"/>
+
+        </phase>
+
+        <!--  System pre defined phases       -->
+
+        <phase name="RMPhase"/>
+
+        <phase name="OpPhase"/>
+
+        <!--   After Postdispatch phase module author or or service author can add any phase he want      -->
+
+        <phase name="OperationInPhase"/>
+
+    </phaseOrder>
+
+    <phaseOrder type="OutFlow">
+
+        <!-- Handlers related to unified-endpoint component are added to the UEPPhase -->
+
+        <phase name="UEPPhase"/>
+
+        <phase name="RMPhase"/>
+
+        <phase name="OpPhase"/>
+
+        <!--      user can add his own phases to this area  -->
+
+        <phase name="OperationOutPhase"/>
+
+        <!--system predefined phase-->
+
+        <!--these phase will run irrespective of the service-->
+
+        <phase name="PolicyDetermination"/>
+
+        <phase name="MessageOut"/>
+
+        <phase name="Security"/>
+
+
+
+        <!--
+
+           The MsgOutObservation phase is used to observe messages just before the
+
+           responses are sent out. In this phase, we could do some things such as SOAP message
+
+           tracing & keeping track of the time at which a particular response was sent.
+
+
+
+           NOTE: This should be the very last phase in this flow
+
+        -->
+
+        <phase name="MsgOutObservation"/>
+
+        <!--Following phase is added to publish stats -->
+
+        <phase name="StatReporting"/>
+
+    </phaseOrder>
+
+    <phaseOrder type="InFaultFlow">
+
+        <!--  System pre defined phases       -->
+
+        <!--
+
+           The MsgInObservation phase is used to observe messages as soon as they are
+
+           received. In this phase, we could do some things such as SOAP message tracing & keeping
+
+           track of the time at which a particular message was received
+
+
+
+           NOTE: This should be the very first phase in this flow
+
+        -->
+
+        <phase name="MsgInObservation"/>
+
+
+
+        <phase name="Validation"/>
+
+        <phase name="Transport">
+
+            <handler name="RequestURIBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.RequestURIBasedDispatcher">
+
+                <order phase="Transport"/>
+
+            </handler>
+
+            <handler name="SOAPActionBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.SOAPActionBasedDispatcher">
+
+                <order phase="Transport"/>
+
+            </handler>
+
+        </phase>
+
+
+
+        <phase name="Addressing">
+
+            <handler name="AddressingBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.AddressingBasedDispatcher">
+
+                <order phase="Addressing"/>
+
+            </handler>
+
+        </phase>
+
+        <phase name="Ghost">
+
+            <handler name="GhostDispatcher"
+
+                     class="org.wso2.carbon.core.dispatchers.GhostDispatcher"/>
+
+        </phase>
+
+        <phase name="Security"/>
+
+        <phase name="PreDispatch"/>
+
+        <phase name="Dispatch" class="org.apache.axis2.engine.DispatchPhase">
+
+            <handler name="RequestURIBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.RequestURIBasedDispatcher"/>
+
+            <handler name="SOAPActionBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.SOAPActionBasedDispatcher"/>
+
+            <handler name="SOAPMessageBodyBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.SOAPMessageBodyBasedDispatcher"/>
+
+
+
+            <handler name="HTTPLocationBasedDispatcher"
+
+                     class="org.apache.axis2.dispatchers.HTTPLocationBasedDispatcher"/>
+
+        </phase>
+
+        <phase name="RMPhase"/>
+
+        <phase name="OpPhase"/>
+
+        <!--      user can add his own phases to this area  -->
+
+        <phase name="OperationInFaultPhase"/>
+
+    </phaseOrder>
+
+    <phaseOrder type="OutFaultFlow">
+
+        <!-- Handlers related to unified-endpoint component are added to the UEPPhase -->
+
+        <phase name="UEPPhase"/>
+
+        <phase name="RMPhase"/>
+
+        <!--      user can add his own phases to this area  -->
+
+        <phase name="OperationOutFaultPhase"/>
+
+        <phase name="PolicyDetermination"/>
+
+        <phase name="MessageOut"/>
+
+        <phase name="Security"/>
+
+	<phase name="Transport"/>
+
+        <!--
+
+           The MsgOutObservation phase is used to observe messages just before the
+
+           responses are sent out. In this phase, we could do some things such as SOAP message
+
+           tracing & keeping track of the time at which a particular response was sent.
+
+
+
+           NOTE: This should be the very last phase in this flow
+
+        -->
+
+        <phase name="MsgOutObservation"/>
+
+        <!--Following phase is added to publish stats -->
+
+        <phase name="StatReporting"/>
+
+    </phaseOrder>
+
+
+
+    <clustering class="org.wso2.carbon.core.clustering.hazelcast.HazelcastClusteringAgent"
+
+                enable="<%= @clustering['enabled'] %>">
+
+
+
+        <!--
+
+           This parameter indicates whether the cluster has to be automatically initalized
+
+           when the AxisConfiguration is built. If set to "true" the initialization will not be
+
+           done at that stage, and some other party will have to explictly initialize the cluster.
+
+        -->
+
+        <parameter name="AvoidInitiation">true</parameter>
+
+
+
+        <!--
+
+           The membership scheme used in this setup. The only values supported at the moment are
+
+           "multicast" and "wka"
+
+
+
+           1. multicast - membership is automatically discovered using multicasting
+
+           2. wka - Well-Known Address based multicasting. Membership is discovered with the help
+
+                    of one or more nodes running at a Well-Known Address. New members joining a
+
+                    cluster will first connect to a well-known node, register with the well-known node
+
+                    and get the membership list from it. When new members join, one of the well-known
+
+                    nodes will notify the others in the group. When a member leaves the cluster or
+
+                    is deemed to have left the cluster, it will be detected by the Group Membership
+
+                    Service (GMS) using a TCP ping mechanism.
+
+        -->
+
+
+
+
+	<!--<parameter name="licenseKey">xxx</parameter>-->
+
+        <!--<parameter name="mgtCenterURL">http://localhost:8081/mancenter/</parameter>-->
+
+
+
+        <!--
+
+         The clustering domain/group. Nodes in the same group will belong to the same multicast
+
+         domain. There will not be interference between nodes in different groups.
+
+        -->
+
+        <parameter name="domain"><%= @clustering['domain'] %></parameter>
+
+
+
+        <!-- The multicast address to be used -->
+
+        <!--<parameter name="mcastAddress">228.0.0.4</parameter>-->
+
+
+
+        <!-- The multicast port to be used -->
+
+        <!-- <parameter name="mcastPort">45564</parameter> -->
+
+
+
+        <!-- <parameter name="mcastTTL">100</parameter> -->
+
+
+
+        <!-- <parameter name="mcastTimeout">60</parameter> -->
+
+
+
+        <!--
+
+           The IP address of the network interface to which the multicasting has to be bound to.
+
+           Multicasting would be done using this interface.
+
+        -->
+
+        <!--
+
+            <parameter name="mcastBindAddress">127.0.0.1</parameter>
+
+        -->
+
+        <!-- The host name or IP address of this member -->
+
+
+
+        <parameter name="localMemberHost"><%= @clustering['local_member_host'] %></parameter>
+
+
+
+        <!--
+
+            The bind adress of this member. The difference between localMemberHost & localMemberBindAddress
+
+            is that localMemberHost is the one that is advertised by this member, while localMemberBindAddress
+
+            is the address to which this member is bound to.
+
+        -->
+
+        <!--
+
+        <parameter name="localMemberBindAddress">127.0.0.1</parameter>
+
+        -->
+
+
+
+        <!--
+
+        The TCP port used by this member. This is the port through which other nodes will
+
+        contact this member
+
+         -->
+
+        <parameter name="localMemberPort"><%= @clustering['local_member_port'] %></parameter>
+
+
+
+        <!--
+
+            The bind port of this member. The difference between localMemberPort & localMemberBindPort
+
+            is that localMemberPort is the one that is advertised by this member, while localMemberBindPort
+
+            is the port to which this member is bound to.
+
+        -->
+
+        <!--
+
+        <parameter name="localMemberBindPort">4001</parameter>
+
+        -->
+
+
+
+        <!--
+
+        Properties specific to this member
+
+        -->
+
+        <parameter name="properties">
+
+            <property name="backendServerURL" value="https://${hostName}:${httpsPort}/services/"/>
+
+            <property name="mgtConsoleURL" value="https://${hostName}:${httpsPort}/"/>
+
+            <property name="subDomain" value="<%= @clustering['sub_domain'] %>"/>
+
+        </parameter>
+
+
+
+        <!--
+
+        Uncomment the following section to load custom Hazelcast data serializers.
+
+        -->
+
+        <!--
+
+        <parameter name="hazelcastSerializers">
+
+            <serializer typeClass="java.util.TreeSet">org.wso2.carbon.hazelcast.serializer.TreeSetSerializer
+
+            </serializer>
+
+            <serializer typeClass="java.util.Map">org.wso2.carbon.hazelcast.serializer.MapSerializer</serializer>
+
+        </parameter>
+
+        -->
+
+
+
+        <!--
+
+           The list of static or well-known members. These entries will only be valid if the
+
+           "membershipScheme" above is set to "wka"
+
+        -->
+
+<%- if @clustering['membership_scheme'] == 'wka' -%>
+
+        <members>
+
+   <%- @clustering['wka']['members'].each do |member| -%>
+
+            <member>
+
+                <hostName><%= member['hostname'] %></hostName>
+
+                <port><%= member['port'] %></port>
+
+            </member>
+
+   <%- end -%>
+
+        </members>
+
+<%- end -%>
+
+
+
+        @value
+
+
+
+
+
+        <!--
+
+        Enable the groupManagement entry if you need to run this node as a cluster manager.
+
+        Multiple application domains with different GroupManagementAgent implementations
+
+        can be defined in this section.
+
+        -->
+
+        <groupManagement enable="false">
+
+            <applicationDomain name="wso2.as.domain"
+
+                               description="AS group"
+
+                               agent="org.wso2.carbon.core.clustering.hazelcast.HazelcastGroupManagementAgent"
+
+                               subDomain="worker"
+
+                               port="2222"/>
+
+        </groupManagement>
+
+    </clustering>
+
+</axisconfig>
+
+

--- a/modules/wso2is/templates/repository/conf/carbon.xml.erb
+++ b/modules/wso2is/templates/repository/conf/carbon.xml.erb
@@ -1,0 +1,707 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+    This is the main server configuration file
+
+    ${carbon.home} represents the carbon.home system property.
+    Other system properties can be specified in a similar manner.
+-->
+<Server xmlns="http://wso2.org/projects/carbon/carbon.xml">
+
+    <!--
+       Product Name
+    -->
+    <Name>WSO2 Identity Server</Name>
+
+    <!--
+       machine readable unique key to identify each product
+    -->
+    <ServerKey>IS</ServerKey>
+
+    <!--
+       Product Version
+    -->
+    <Version>5.6.0</Version>
+
+    <!--
+       Host name or IP address of the machine hosting this server
+       e.g. www.wso2.org, 192.168.1.10
+       This is will become part of the End Point Reference of the
+       services deployed on this server instance.
+    -->
+    <HostName><%= @hostname %></HostName>
+    <!--
+    Host name to be used for the Carbon management console
+    -->
+    <MgtHostName><%= @mgt_hostname %></MgtHostName>
+    <!--MgtHostName>mgt.wso2.org</MgtHostName-->
+
+    <!--
+        The URL of the back end server. This is where the admin services are hosted and
+        will be used by the clients in the front end server.
+        This is required only for the Front-end server. This is used when seperating BE server from FE server
+       -->
+    <ServerURL>local:/${carbon.context}/services/</ServerURL>
+    <!--
+    <ServerURL>https://localhost:${carbon.management.port}${carbon.context}/services/</ServerURL>
+    -->
+     <!--
+     The URL of the index page. This is where the user will be redirected after signing in to the
+     carbon server.
+     -->
+    <!-- IndexPageURL>/carbon/admin/index.jsp</IndexPageURL-->
+
+    <!--
+    For cApp deployment, we have to identify the roles that can be acted by the current server.
+    The following property is used for that purpose. Any number of roles can be defined here.
+    Regular expressions can be used in the role.
+    Ex : <Role>.*</Role> means this server can act any role
+    -->
+    <ServerRoles>
+        <Role>IdentityServer</Role>
+    </ServerRoles>
+
+    <!-- uncommnet this line to subscribe to a bam instance automatically -->
+    <!--<BamServerURL>https://bamhost:bamport/services/</BamServerURL>-->
+
+    <!--
+       The fully qualified name of the server
+    -->
+    <Package>org.wso2.carbon</Package>
+
+    <!--
+       Webapp context root of WSO2 Carbon management console.
+    -->
+    <WebContextRoot>/</WebContextRoot>
+
+    <!--
+    	Proxy context path is a useful parameter to add a proxy path when a Carbon server is fronted by reverse proxy. In addtion
+        to the proxy host and proxy port this parameter allows you add a path component to external URLs. e.g.
+     		URL of the Carbon server -> https://10.100.1.1:9443/carbon
+   		URL of the reverse proxy -> https://prod.abc.com/appserver/carbon
+
+   	appserver - proxy context path. This specially required whenever you are generating URLs to displace in
+   	Carbon UI components.
+    -->
+    <!--
+    	<MgtProxyContextPath></MgtProxyContextPath>
+    	<ProxyContextPath></ProxyContextPath>
+    -->
+
+    <!-- In-order to  get the registry http Port from the back-end when the default http transport is not the same-->
+    <!--RegistryHttpPort>9763</RegistryHttpPort-->
+
+    <!--
+    Number of items to be displayed on a management console page. This is used at the
+    backend server for pagination of various items.
+    -->
+    <ItemsPerPage>15</ItemsPerPage>
+
+    <!-- The endpoint URL of the cloud instance management Web service -->
+    <!--<InstanceMgtWSEndpoint>https://ec2.amazonaws.com/</InstanceMgtWSEndpoint>-->
+
+    <!--
+       Ports used by this server
+    -->
+    <Ports>
+
+        <!-- Ports offset. This entry will set the value of the ports defined below to
+         the define value + Offset.
+         e.g. Offset=2 and HTTPS port=9443 will set the effective HTTPS port to 9445
+         -->
+        <Offset><%= @ports['offset'] %></Offset>
+
+        <!-- The JMX Ports -->
+        <JMX>
+            <!--The port RMI registry is exposed-->
+            <RMIRegistryPort>9999</RMIRegistryPort>
+            <!--The port RMI server should be exposed-->
+            <RMIServerPort>11111</RMIServerPort>
+        </JMX>
+
+        <!-- Embedded LDAP server specific ports -->
+        <EmbeddedLDAP>
+            <!-- Port which embedded LDAP server runs -->
+            <LDAPServerPort>10389</LDAPServerPort>
+            <!-- Port which KDC (Kerberos Key Distribution Center) server runs -->
+            <KDCServerPort>8000</KDCServerPort>
+        </EmbeddedLDAP>
+
+	<!--
+             Override datasources JNDIproviderPort defined in bps.xml and datasources.properties files
+	-->
+	<!--<JNDIProviderPort>2199</JNDIProviderPort>-->
+	<!--Override receive port of thrift based entitlement service.-->
+	<ThriftEntitlementReceivePort>10500</ThriftEntitlementReceivePort>
+
+    <!--
+     This is the proxy port of the worker cluster. These need to be configured in a scenario where
+     manager node is not exposed through the load balancer through which the workers are exposed
+     therefore doesn't have a proxy port.
+    <WorkerHttpProxyPort>80</WorkerHttpProxyPort>
+    <WorkerHttpsProxyPort>443</WorkerHttpsProxyPort>
+    -->
+
+    </Ports>
+
+    <!--
+        JNDI Configuration
+    -->
+    <JNDI>
+        <!--
+             The fully qualified name of the default initial context factory
+        -->
+        <DefaultInitialContextFactory>org.wso2.carbon.tomcat.jndi.CarbonJavaURLContextFactory</DefaultInitialContextFactory>
+        <!--
+             The restrictions that are done to various JNDI Contexts in a Multi-tenant environment
+        -->
+        <Restrictions>
+            <!--
+                Contexts that will be available only to the super-tenant
+            -->
+            <!-- <SuperTenantOnly>
+                <UrlContexts>
+                    <UrlContext>
+                        <Scheme>foo</Scheme>
+                    </UrlContext>
+                    <UrlContext>
+                        <Scheme>bar</Scheme>
+                    </UrlContext>
+                </UrlContexts>
+            </SuperTenantOnly> -->
+            <!--
+                Contexts that are common to all tenants
+            -->
+            <AllTenants>
+                <UrlContexts>
+                    <UrlContext>
+                        <Scheme>java</Scheme>
+                    </UrlContext>
+                    <!-- <UrlContext>
+                        <Scheme>foo</Scheme>
+                    </UrlContext> -->
+                </UrlContexts>
+            </AllTenants>
+            <!--
+                 All other contexts not mentioned above will be available on a per-tenant basis
+                 (i.e. will not be shared among tenants)
+            -->
+        </Restrictions>
+    </JNDI>
+
+    <!--
+        Property to determine if the server is running an a cloud deployment environment.
+        This property should only be used to determine deployment specific details that are
+        applicable only in a cloud deployment, i.e when the server deployed *-as-a-service.
+    -->
+    <IsCloudDeployment>false</IsCloudDeployment>
+
+    <!--
+	Property to determine whether usage data should be collected for metering purposes
+    -->
+    <EnableMetering>false</EnableMetering>
+
+    <!-- The Max time a thread should take for execution in seconds -->
+    <MaxThreadExecutionTime>600</MaxThreadExecutionTime>
+
+    <!--
+        A flag to enable or disable Ghost Deployer. By default this is set to false. That is
+        because the Ghost Deployer works only with the HTTP/S transports. If you are using
+        other transports, don't enable Ghost Deployer.
+    -->
+    <GhostDeployment>
+        <Enabled>false</Enabled>
+    </GhostDeployment>
+
+
+    <!--
+        Eager loading or lazy loading is a design pattern commonly used in computer programming which
+        will initialize an object upon creation or load on-demand. In carbon, lazy loading is used to
+        load tenant when a request is received only. Similarly Eager loading is used to enable load
+        existing tenants after carbon server starts up. Using this feature, you will be able to include
+        or exclude tenants which are to be loaded when server startup.
+
+        We can enable only one LoadingPolicy at a given time.
+
+        1. Tenant Lazy Loading
+           This is the default behaviour and enabled by default. With this policy, tenants are not loaded at
+           server startup, but loaded based on-demand (i.e when a request is received for a tenant).
+           The default tenant idle time is 30 minutes.
+
+        2. Tenant Eager Loading
+           This is by default not enabled. It can be be enabled by un-commenting the <EagerLoading> section.
+           The eager loading configurations supported are as below. These configurations can be given as the
+           value for <Include> element with eager loading.
+                (i)Load all tenants when server startup             -   *
+                (ii)Load all tenants except foo.com & bar.com       -   *,!foo.com,!bar.com
+                (iii)Load only foo.com &  bar.com to be included    -   foo.com,bar.com
+    -->
+    <Tenant>
+        <LoadingPolicy>
+            <LazyLoading>
+                <IdleTime>30</IdleTime>
+            </LazyLoading>
+            <!-- <EagerLoading>
+                   <Include>*,!foo.com,!bar.com</Include>
+            </EagerLoading>-->
+        </LoadingPolicy>
+    </Tenant>
+
+    <!--
+     Caching related configurations
+    -->
+    <Cache>
+        <!-- Default cache timeout in minutes -->
+        <DefaultCacheTimeout>15</DefaultCacheTimeout>
+        <!-- Force all caches to act as local -->
+        <ForceLocalCache>false</ForceLocalCache>
+    </Cache>
+
+    <!--
+    Axis2 related configurations
+    -->
+    <Axis2Config>
+        <!--
+             Location of the Axis2 Services & Modules repository
+
+             This can be a directory in the local file system, or a URL.
+
+             e.g.
+             1. /home/wso2wsas/repository/ - An absolute path
+             2. repository - In this case, the path is relative to CARBON_HOME
+             3. file:///home/wso2wsas/repository/
+             4. http://wso2wsas/repository/
+        -->
+        <RepositoryLocation>${carbon.home}/repository/deployment/server/</RepositoryLocation>
+
+        <!--
+         Deployment update interval in seconds. This is the interval between repository listener
+         executions.
+        -->
+        <DeploymentUpdateInterval>15</DeploymentUpdateInterval>
+
+        <!--
+            Location of the main Axis2 configuration descriptor file, a.k.a. axis2.xml file
+
+            This can be a file on the local file system, or a URL
+
+            e.g.
+            1. /home/repository/axis2.xml - An absolute path
+            2. conf/axis2.xml - In this case, the path is relative to CARBON_HOME
+            3. file:///home/carbon/repository/axis2.xml
+            4. http://repository/conf/axis2.xml
+        -->
+        <ConfigurationFile>${carbon.home}/repository/conf/axis2/axis2.xml</ConfigurationFile>
+
+        <!--
+          ServiceGroupContextIdleTime, which will be set in ConfigurationContex
+          for multiple clients which are going to access the same ServiceGroupContext
+          Default Value is 30 Sec.
+        -->
+        <ServiceGroupContextIdleTime>30000</ServiceGroupContextIdleTime>
+
+        <!--
+          This repository location is used to crete the client side configuration
+          context used by the server when calling admin services.
+        -->
+        <ClientRepositoryLocation>${carbon.home}/repository/deployment/client/</ClientRepositoryLocation>
+        <!-- This axis2 xml is used in createing the configuration context by the FE server
+         calling to BE server -->
+        <clientAxis2XmlLocation>${carbon.home}/repository/conf/axis2/axis2_client.xml</clientAxis2XmlLocation>
+        <!-- If this parameter is set, the ?wsdl on an admin service will not give the admin service wsdl. -->
+        <HideAdminServiceWSDLs>true</HideAdminServiceWSDLs>
+
+	<!--WARNING-Use With Care! Uncommenting bellow parameter would expose all AdminServices in HTTP transport.
+	With HTTP transport your credentials and data routed in public channels are vulnerable for sniffing attacks.
+	Use bellow parameter ONLY if your communication channels are confirmed to be secured by other means -->
+        <!--HttpAdminServices>*</HttpAdminServices-->
+
+    </Axis2Config>
+
+    <!--
+       The default user roles which will be created when the server
+       is started up for the first time.
+    -->
+    <ServiceUserRoles>
+        <Role>
+            <Name>admin</Name>
+            <Description>Default Administrator Role</Description>
+        </Role>
+        <Role>
+            <Name>user</Name>
+            <Description>Default User Role</Description>
+        </Role>
+    </ServiceUserRoles>
+
+    <!--
+      Enable following config to allow Emails as usernames.
+    -->
+    <!--EnableEmailUserName>true</EnableEmailUserName-->
+
+    <!--
+      Security configurations
+    -->
+    <Security>
+        <!--
+            KeyStore which will be used for encrypting/decrypting passwords
+            and other sensitive information.
+        -->
+   <KeyStore>
+            <!-- Keystore file location-->
+            <Location>${carbon.home}/<%= @key_stores['key_store']['location'] %></Location>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type><%= @key_stores['key_store']['type'] %></Type>
+            <!-- Keystore password-->
+            <% if @enable_secure_vault %>
+            <Password svns:secretAlias="Carbon.Security.KeyStore.Password">password</Password>
+            <%- else -%>
+            <Password><%= @key_stores['key_store']['password'] %></Password>
+            <% end %>
+            <!-- Private Key alias-->
+            <KeyAlias><%= @key_stores['key_store']['key_alias'] %></KeyAlias>
+            <!-- Private Key password-->
+            <% if @enable_secure_vault %>
+            <KeyPassword svns:secretAlias="Carbon.Security.KeyStore.KeyPassword">password</KeyPassword>
+            <%- else -%>
+            <KeyPassword><%= @key_stores['key_store']['key_password'] %></KeyPassword>
+            <% end %>
+        </KeyStore>
+
+        <!--
+            System wide trust-store which is used to maintain the certificates of all
+            the trusted parties.
+        -->
+        <TrustStore>
+            <!-- trust-store file location -->
+            <Location>${carbon.home}/<%= @key_stores['trust_store']['location'] %></Location>
+            <!-- trust-store type (JKS/PKCS12 etc.) -->
+            <Type><%= @key_stores['trust_store']['type'] %></Type>
+            <!-- trust-store password -->
+            <% if @enable_secure_vault %>
+            <Password svns:secretAlias="Carbon.Security.TrustStore.Password">password</Password>
+            <%- else -%>
+            <Password><%= @key_stores['trust_store']['password'] %></Password>
+            <% end %>
+        </TrustStore>
+
+        <!--
+            The Authenticator configuration to be used at the JVM level. We extend the
+            java.net.Authenticator to make it possible to authenticate to given servers and
+            proxies.
+        -->
+        <NetworkAuthenticatorConfig>
+            <!--
+                Below is a sample configuration for a single authenticator. Please note that
+                all child elements are mandatory. Not having some child elements would lead to
+                exceptions at runtime.
+            -->
+            <!-- <Credential> -->
+                <!--
+                    the pattern that would match a subset of URLs for which this authenticator
+                    would be used
+                -->
+                <!-- <Pattern>regularExpression</Pattern> -->
+                <!--
+                    the type of this authenticator. Allowed values are:
+                    1. server
+                    2. proxy
+                -->
+                <!-- <Type>proxy</Type> -->
+                <!-- the username used to log in to server/proxy -->
+                <!-- <Username>username</Username> -->
+                <!-- the password used to log in to server/proxy -->
+                <!-- <Password>password</Password> -->
+            <!-- </Credential> -->
+        </NetworkAuthenticatorConfig>
+
+        <!--
+         The Tomcat realm to be used for hosted Web applications. Allowed values are;
+         1. UserManager
+         2. Memory
+
+         If this is set to 'UserManager', the realm will pick users & roles from the system's
+         WSO2 User Manager. If it is set to 'memory', the realm will pick users & roles from
+         CARBON_HOME/repository/conf/tomcat/tomcat-users.xml
+        -->
+        <TomcatRealm>UserManager</TomcatRealm>
+
+	<!--Option to disable storing of tokens issued by STS-->
+	<DisableTokenStore>false</DisableTokenStore>
+
+ <STSCallBackHandlerName>org.wso2.carbon.identity.provider.AttributeCallbackHandler</STSCallBackHandlerName>
+
+	<!--
+	 Security token store class name. If this is not set, default class will be
+	 org.wso2.carbon.security.util.SecurityTokenStore
+	-->
+	<TokenStoreClassName>org.wso2.carbon.identity.sts.store.DBTokenStore</TokenStoreClassName>
+
+        <XSSPreventionConfig>
+            <Enabled>true</Enabled>
+            <Rule>allow</Rule>
+            <Patterns>
+                <!--Pattern></Pattern-->
+            </Patterns>
+        </XSSPreventionConfig>
+    </Security>
+<HideMenuItemIds>
+<HideMenuItemId>claim_mgt_menu</HideMenuItemId>
+<HideMenuItemId>identity_mgt_emailtemplate_menu</HideMenuItemId>
+<HideMenuItemId>identity_security_questions_menu</HideMenuItemId>
+</HideMenuItemIds>
+
+    <!--
+       The temporary work directory
+    -->
+    <WorkDirectory>${carbon.home}/tmp/work</WorkDirectory>
+
+    <!--
+       House-keeping configuration
+    -->
+    <HouseKeeping>
+
+        <!--
+           true  - Start House-keeping thread on server startup
+           false - Do not start House-keeping thread on server startup.
+                   The user will run it manually as and when he wishes.
+        -->
+        <AutoStart>true</AutoStart>
+
+        <!--
+           The interval in *minutes*, between house-keeping runs
+        -->
+        <Interval>10</Interval>
+
+        <!--
+          The maximum time in *minutes*, temp files are allowed to live
+          in the system. Files/directories which were modified more than
+          "MaxTempFileLifetime" minutes ago will be removed by the
+          house-keeping task
+        -->
+        <MaxTempFileLifetime>30</MaxTempFileLifetime>
+    </HouseKeeping>
+
+    <!--
+       Configuration for handling different types of file upload & other file uploading related
+       config parameters.
+       To map all actions to a particular FileUploadExecutor, use
+       <Action>*</Action>
+    -->
+    <FileUploadConfig>
+        <!--
+           The total file upload size limit in MB
+        -->
+        <TotalFileSizeLimit>100</TotalFileSizeLimit>
+
+        <Mapping>
+            <Actions>
+                <Action>keystore</Action>
+                <Action>certificate</Action>
+                <Action>*</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.AnyFileUploadExecutor</Class>
+        </Mapping>
+
+        <Mapping>
+            <Actions>
+                <Action>jarZip</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.JarZipUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>dbs</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.DBSFileUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>tools</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.ToolsFileUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>toolsAny</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.ToolsAnyFileUploadExecutor</Class>
+        </Mapping>
+    </FileUploadConfig>
+
+    <!-- FileNameRegEx is used to validate the file input/upload/write-out names.
+    e.g.
+     <FileNameRegEx>^(?!(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\.[^.])?$)[^&lt;&gt:"/\\|?*\x00-\x1F][^&lt;&gt:"/\\|?*\x00-\x1F\ .]$</FileNameRegEx>
+    -->
+    <!--<FileNameRegEx></FileNameRegEx>-->
+
+    <!--
+       Processors which process special HTTP GET requests such as ?wsdl, ?policy etc.
+
+       In order to plug in a processor to handle a special request, simply add an entry to this
+       section.
+
+       The value of the Item element is the first parameter in the query string(e.g. ?wsdl)
+       which needs special processing
+
+       The value of the Class element is a class which implements
+       org.wso2.carbon.transport.HttpGetRequestProcessor
+    -->
+    <HttpGetRequestProcessors>
+        <Processor>
+            <Item>info</Item>
+            <Class>org.wso2.carbon.core.transports.util.InfoProcessor</Class>
+        </Processor>
+        <Processor>
+            <Item>wsdl</Item>
+            <Class>org.wso2.carbon.core.transports.util.Wsdl11Processor</Class>
+        </Processor>
+        <Processor>
+            <Item>wsdl2</Item>
+            <Class>org.wso2.carbon.core.transports.util.Wsdl20Processor</Class>
+        </Processor>
+        <Processor>
+            <Item>xsd</Item>
+            <Class>org.wso2.carbon.core.transports.util.XsdProcessor</Class>
+        </Processor>
+    </HttpGetRequestProcessors>
+
+    <!-- Deployment Synchronizer Configuration. Enable value to true when running with "svn based" dep sync.
+	In master nodes you need to set both AutoCommit and AutoCheckout to true
+	and in  worker nodes set only AutoCheckout to true.
+    -->
+
+
+  <DeploymentSynchronizer>
+        <Enabled><%= @dep_sync['enabled'] %></Enabled>
+        <AutoCommit><%= @dep_sync['auto_commit'] %></AutoCommit>
+        <AutoCheckout><%= @dep_sync['auto_checkout'] %></AutoCheckout>
+        <RepositoryType><%= @dep_sync['repository_type'] %></RepositoryType>
+    <%- if @dep_sync['repository_type'] == "svn" -%>
+        <SvnUrl><%= @dep_sync['svn']['url'] -%></SvnUrl>
+        <SvnUser><%= @dep_sync['svn']['user'] -%></SvnUser>
+        <SvnPassword><%= @dep_sync['svn']['password'] -%></SvnPassword>
+        <SvnUrlAppendTenantId><%= @dep_sync['svn']['append_tenant_id'] -%></SvnUrlAppendTenantId>
+    <%- end -%>
+    </DeploymentSynchronizer>
+
+    <!-- Deployment Synchronizer Configuration. Uncomment the following section when running with "registry based" dep sync.
+        In master nodes you need to set both AutoCommit and AutoCheckout to true
+        and in  worker nodes set only AutoCheckout to true.
+    -->
+    <!--<DeploymentSynchronizer>
+        <Enabled>true</Enabled>
+        <AutoCommit>false</AutoCommit>
+        <AutoCheckout>true</AutoCheckout>
+        <RepositoryType>svn</RepositoryType>
+        <SvnUrl>http://svnrepo.example.com/repos/</SvnUrl>
+        <SvnUser>username</SvnUser>
+        <SvnPassword>password</SvnPassword>
+        <SvnUrlAppendTenantId>true</SvnUrlAppendTenantId>
+    </DeploymentSynchronizer>
+
+    <!Mediation persistence configurations. Only valid if mediation features are available i.e. ESB -->
+    <!--<MediationConfig>
+        <LoadFromRegistry>false</LoadFromRegistry>
+        <SaveToFile>false</SaveToFile>
+        <Persistence>enabled</Persistence>
+        <RegistryPersistence>enabled</RegistryPersistence>
+    </MediationConfig>-->
+
+    <!--
+    Server intializing code, specified as implementation classes of org.wso2.carbon.core.ServerInitializer.
+    This code will be run when the Carbon server is initialized
+    -->
+    <ServerInitializers>
+        <!--<Initializer></Initializer>-->
+    </ServerInitializers>
+
+    <!--
+    Indicates whether the Carbon Servlet is required by the system, and whether it should be
+    registered
+    -->
+    <RequireCarbonServlet>${require.carbon.servlet}</RequireCarbonServlet>
+
+    <!--
+    Carbon H2 OSGI Configuration
+    By default non of the servers start.
+        name="web" - Start the web server with the H2 Console
+        name="webPort" - The port (default: 8082)
+        name="webAllowOthers" - Allow other computers to connect
+        name="webSSL" - Use encrypted (HTTPS) connections
+        name="tcp" - Start the TCP server
+        name="tcpPort" - The port (default: 9092)
+        name="tcpAllowOthers" - Allow other computers to connect
+        name="tcpSSL" - Use encrypted (SSL) connections
+        name="pg" - Start the PG server
+        name="pgPort"  - The port (default: 5435)
+        name="pgAllowOthers"  - Allow other computers to connect
+        name="trace" - Print additional trace information; for all servers
+        name="baseDir" - The base directory for H2 databases; for all servers
+    -->
+    <!--H2DatabaseConfiguration>
+        <property name="web" />
+        <property name="webPort">8082</property>
+        <property name="webAllowOthers" />
+        <property name="webSSL" />
+        <property name="tcp" />
+        <property name="tcpPort">9092</property>
+        <property name="tcpAllowOthers" />
+        <property name="tcpSSL" />
+        <property name="pg" />
+        <property name="pgPort">5435</property>
+        <property name="pgAllowOthers" />
+        <property name="trace" />
+        <property name="baseDir">${carbon.home}</property>
+    </H2DatabaseConfiguration-->
+    <!--Disabling statistics reporter by default-->
+    <StatisticsReporterDisabled>true</StatisticsReporterDisabled>
+
+    <!-- Enable accessing Admin Console via HTTP -->
+    <!-- EnableHTTPAdminConsole>true</EnableHTTPAdminConsole -->
+
+    <!--
+       Default Feature Repository of WSO2 Carbon.
+    -->
+    <FeatureRepository>
+	    <RepositoryName>default repository</RepositoryName>
+	    <RepositoryURL>http://product-dist.wso2.com/p2/carbon/releases/wilkes/</RepositoryURL>
+    </FeatureRepository>
+
+    <!--
+	Configure API Management
+   -->
+   <APIManagement>
+
+	<!--Uses the embedded API Manager by default. If you want to use an external
+	API Manager instance to manage APIs, configure below  externalAPIManager-->
+
+	<Enabled>true</Enabled>
+
+	<!--Uncomment and configure API Gateway and
+	Publisher URLs to use external API Manager instance-->
+
+	<!--ExternalAPIManager>
+
+		<APIGatewayURL>http://localhost:8281</APIGatewayURL>
+		<APIPublisherURL>http://localhost:8281/publisher</APIPublisherURL>
+
+	</ExternalAPIManager-->
+
+	<LoadAPIContextsInServerStartup>true</LoadAPIContextsInServerStartup>
+   </APIManagement>
+</Server>

--- a/modules/wso2is/templates/repository/conf/datasources/master-datasources.xml.erb
+++ b/modules/wso2is/templates/repository/conf/datasources/master-datasources.xml.erb
@@ -1,0 +1,122 @@
+<datasources-configuration xmlns:svns="http://org.wso2.securevault/configuration">
+
+    <providers>
+        <provider>org.wso2.carbon.ndatasource.rdbms.RDBMSDataSourceReader</provider>
+    </providers>
+
+    <datasources>
+      <datasource>
+          <name>WSO2_CARBON_DB</name>
+          <description>The datasource used for registry and user manager</description>
+          <jndiConfig>
+              <name>jdbc/WSO2CarbonDB</name>
+          </jndiConfig>
+          <definition type="RDBMS">
+              <configuration>
+                  <url>jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
+                  <username>wso2carbon</username>
+                  <password>wso2carbon</password>
+                  <driverClassName>org.h2.Driver</driverClassName>
+                  <maxActive>50</maxActive>
+                  <maxWait>60000</maxWait>
+                  <testOnBorrow>true</testOnBorrow>
+                  <validationQuery>SELECT 1</validationQuery>
+                  <validationInterval>30000</validationInterval>
+                  <defaultAutoCommit>false</defaultAutoCommit>
+              </configuration>
+          </definition>
+      </datasource>
+
+        <datasource>
+            <name><%= @wso2_reg_db['name'] %></name>
+            <description>The datasource used for registry</description>
+            <jndiConfig>
+                <name><%= @wso2_reg_db['jndi_config'] %></name>
+            </jndiConfig>
+            <definition type="RDBMS">
+                <configuration>
+                    <url><%= @wso2_reg_db['url'] %></url>
+                    <username><%= @wso2_reg_db['username'] %></username>
+                    <password><%= @wso2_reg_db['password'] %></password>
+                    <driverClassName><%= @wso2_reg_db['driver_class_name'] %></driverClassName>
+                    <maxActive><%= @wso2_reg_db['max_active'] %></maxActive>
+                    <maxWait><%= @wso2_reg_db['max_wait'] %></maxWait>
+                    <minIdle>5</minIdle>
+                    <testOnBorrow><%= @wso2_reg_db['test_on_borrow'] %></testOnBorrow>
+                    <validationQuery><%= @wso2_reg_db['validation_query'] %></validationQuery>
+                    <validationInterval><%= @wso2_reg_db['validation_interval'] %></validationInterval>
+                    <defaultAutoCommit>false</defaultAutoCommit>
+                </configuration>
+            </definition>
+        </datasource>
+
+        <datasource>
+            <name><%= @wso2_user_db['name'] %></name>
+            <description>The datasource used for user management</description>
+            <jndiConfig>
+                <name><%= @wso2_user_db['jndi_config'] %></name>
+            </jndiConfig>
+            <definition type="RDBMS">
+                <configuration>
+                    <url><%= @wso2_user_db['url'] %></url>
+                    <username><%= @wso2_user_db['username'] %></username>
+                    <password><%= @wso2_user_db['password'] %></password>
+                    <driverClassName><%= @wso2_user_db['driver_class_name'] %></driverClassName>
+                    <maxActive><%= @wso2_user_db['max_active'] %></maxActive>
+                    <maxWait><%= @wso2_user_db['max_wait'] %></maxWait>
+                    <minIdle>5</minIdle>
+                    <testOnBorrow><%= @wso2_user_db['test_on_borrow'] %></testOnBorrow>
+                    <validationQuery><%= @wso2_user_db['validation_query'] %></validationQuery>
+                    <validationInterval><%= @wso2_user_db['validation_interval'] %></validationInterval>
+                    <defaultAutoCommit><%= @wso2_user_db['default_auto_commit'] %></defaultAutoCommit>
+                </configuration>
+            </definition>
+        </datasource>
+
+        <datasource>
+            <name><%= @wso2_identity_db['name'] %></name>
+            <description>The datasource used for identity management</description>
+            <jndiConfig>
+                <name><%= @wso2_identity_db['jndi_config'] %></name>
+            </jndiConfig>
+            <definition type="RDBMS">
+                <configuration>
+                    <url><%= @wso2_identity_db['url'] %></url>
+                    <username><%= @wso2_identity_db['username'] %></username>
+                    <password><%= @wso2_identity_db['password'] %></password>
+                    <driverClassName><%= @wso2_identity_db['driver_class_name'] %></driverClassName>
+                    <maxActive><%= @wso2_identity_db['max_active'] %></maxActive>
+                    <maxWait><%= @wso2_identity_db['max_wait'] %></maxWait>
+                    <minIdle>5</minIdle>
+                    <testOnBorrow><%= @wso2_identity_db['test_on_borrow'] %></testOnBorrow>
+                    <validationQuery><%= @wso2_identity_db['validation_query'] %></validationQuery>
+                    <validationInterval><%= @wso2_identity_db['validation_interval'] %></validationInterval>
+                    <defaultAutoCommit><%= @wso2_identity_db['default_auto_commit'] %></defaultAutoCommit>
+                </configuration>
+            </definition>
+        </datasource>
+
+        <datasource>
+            <name><%= @wso2_consent_db['name'] %></name>
+            <description>The datasource used for consent management</description>
+            <jndiConfig>
+                <name><%= @wso2_consent_db['jndi_config'] %></name>
+            </jndiConfig>
+            <definition type="RDBMS">
+                <configuration>
+                    <url><%= @wso2_consent_db['url'] %></url>
+                    <username><%= @wso2_consent_db['username'] %></username>
+                    <password><%= @wso2_consent_db['password'] %></password>
+                    <driverClassName><%= @wso2_consent_db['driver_class_name'] %></driverClassName>
+                    <maxActive><%= @wso2_consent_db['max_active'] %></maxActive>
+                    <maxWait><%= @wso2_consent_db['max_wait'] %></maxWait>
+                    <minIdle>5</minIdle>
+                    <testOnBorrow><%= @wso2_consent_db['test_on_borrow'] %></testOnBorrow>
+                    <validationQuery><%= @wso2_consent_db['validation_query'] %></validationQuery>
+                    <validationInterval><%= @wso2_consent_db['validation_interval'] %></validationInterval>
+                    <defaultAutoCommit><%= @wso2_consent_db['default_auto_commit'] %></defaultAutoCommit>
+                </configuration>
+            </definition>
+        </datasource>
+    </datasources>
+</datasources-configuration>

--- a/modules/wso2is/templates/repository/conf/identity/identity.xml.erb
+++ b/modules/wso2is/templates/repository/conf/identity/identity.xml.erb
@@ -1,0 +1,890 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+~ Copyright (c) 2011, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+ -->
+
+<Server xmlns="http://wso2.org/projects/carbon/carbon.xml">
+
+  <JDBCPersistenceManager>
+    <DataSource>
+      <!-- Include a data source name (jndiConfigName) from the set of data
+      sources defined in master-datasources.xml -->
+      <Name><%= @wso2_identity_db['jndi_config'] %></Name>
+    </DataSource>
+    <!-- If the identity database is created from another place and if it is
+        required to skip schema initialization during the server start up, set the
+        following property to "true". -->
+    <!-- <SkipDBSchemaCreation>false</SkipDBSchemaCreation> -->
+    <SessionDataPersist>
+        <Enable>true</Enable>
+        <Temporary>true</Temporary>
+        <PoolSize>0</PoolSize>
+        <SessionDataCleanUp>
+            <Enable>true</Enable>
+            <CleanUpTimeout>20160</CleanUpTimeout>
+            <CleanUpPeriod>1140</CleanUpPeriod>
+            <!--Instead of deleting all the records at once, we are deleting the records in chunks to prevent the -->
+            <!--possible deadlock and lock scenarios. The following property defines the chunk size.-->
+            <DeleteChunkSize>50000</DeleteChunkSize>
+        </SessionDataCleanUp>
+        <OperationDataCleanUp>
+            <Enable>true</Enable>
+        </OperationDataCleanUp>
+        <TempDataCleanup>
+            <!-- Enabling separated cleanup for temporary authentication context data -->
+            <Enable>true</Enable>
+            <!-- When PoolZize > 0, temporary data which have no usage after the authentication flow will be deleted immediately
+             When PoolZise = 0, data will be deleted only by the scheduled cleanup task-->
+            <PoolSize>20</PoolSize>
+            <!-- All temporary authentication context data older than CleanUpTimeout value are considered as expired
+            and would be deleted during cleanup task -->
+            <CleanUpTimeout>40</CleanUpTimeout>
+        </TempDataCleanup>
+    </SessionDataPersist>
+</JDBCPersistenceManager>
+
+<!-- Time configurations are in minutes -->
+<TimeConfig>
+    <SessionIdleTimeout>15</SessionIdleTimeout>
+    <RememberMeTimeout>20160</RememberMeTimeout>
+</TimeConfig>
+
+<!-- Security configurations -->
+<Security>
+    <!-- The directory under which all other KeyStore files will be stored -->
+    <KeyStoresDir>${carbon.home}/conf/keystores</KeyStoresDir>
+    <KeyManagerType>SunX509</KeyManagerType>
+    <TrustManagerType>SunX509</TrustManagerType>
+</Security>
+
+<Identity>
+    <IssuerPolicy>SelfAndManaged</IssuerPolicy>
+    <TokenValidationPolicy>CertValidate</TokenValidationPolicy>
+    <BlackList></BlackList>
+    <WhiteList></WhiteList>
+    <System>
+        <KeyStore></KeyStore>
+        <StorePass></StorePass>
+    </System>
+</Identity>
+
+<OpenID>
+    <!--
+        Default values for OpenIDServerUrl and OpenIDUSerPattern are built in following format
+        https://<HostName>:<MgtTrpProxyPort except 443>/<ProxyContextPath>/<context>
+        If above format doesn't satisfy uncomment the following configs and explicitly configure the values
+     -->
+    <OpenIDServerUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/openidserver</OpenIDServerUrl>
+    <OpenIDUserPattern>${carbon.protocol}://${carbon.host}:${carbon.management.port}/openid</OpenIDUserPattern>
+    <OpenIDLoginUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/openid_login.do</OpenIDLoginUrl>
+    <!-- If the users must be prompted for approval -->
+    <OpenIDSkipUserConsent>false</OpenIDSkipUserConsent>
+    <!-- Expiry time of the OpenID RememberMe token in minutes -->
+    <OpenIDRememberMeExpiry>7200</OpenIDRememberMeExpiry>
+    <!-- To enable or disable openid dumb mode -->
+    <DisableOpenIDDumbMode>false</DisableOpenIDDumbMode>
+    <!--
+           OpenID private association store is configurable from following configs.
+           It includes two new replication stores,
+                   i.   OpenIDServerAssociationStore (Default association store)
+                   ii.  PrivateAssociationCryptoStore
+                   iii. PrivateAssociationReplicationStore
+    -->
+
+    <!-- Specify full qualified class name of the class which going to use as private association store -->
+    <!--
+<OpenIDPrivateAssociationStoreClass>org.wso2.carbon.identity.provider.openid.PrivateAssociationCryptoStore</OpenIDPrivateAssociationStoreClass>
+-->
+
+    <!-- The expiration time (in minutes) for the OpenID association -->
+    <!--
+<OpenIDAssociationExpiryTime>15</OpenIDAssociationExpiryTime>
+-->
+
+    <!-- Configs specific to PrivateAssociationCryptoStore -->
+    <!-- Server secret. This value should be the same in all nodes in the cluster -->
+    <!--
+<OpenIDPrivateAssociationServerKey>qewlj324lmasc</OpenIDPrivateAssociationServerKey>
+-->
+
+    <!-- Configs specific to PrivateAssociationCryptoStore -->
+    <!-- This enable private association cleanup task which cleans expired private associations -->
+    <!--
+<EnableOpenIDAssociationCleanupTask>true</EnableOpenIDAssociationCleanupTask>
+-->
+    <!-- Time Period (in minutes) that cleanup task would run -->
+    <!--
+<OpenIDAssociationCleanupPeriod>15</OpenIDAssociationCleanupPeriod>
+-->
+</OpenID>
+
+<OAuth>
+    <!-- Specify the Token issuer class to be used.
+         Default: org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl.
+         Applicable values: org.wso2.carbon.identity.oauth2.token.JWTTokenIssuer
+    -->
+    <!--<IdentityOAuthTokenGenerator>org.wso2.carbon.identity.oauth2.token.JWTTokenIssuer</IdentityOAuthTokenGenerator>-->
+
+    <!-- True, if access token alias is stored in the database instead of access token.
+         Eg. token alias and token is same when default AccessTokenValueGenerator is used.
+         When JWTTokenIssuer is used, jti is used as the token alias
+         Default: true.
+         Applicable values: true,false
+    -->
+    <!--<PersistAccessTokenAlias>false</PersistAccessTokenAlias>-->
+
+    <!-- This configuration is used to specify the access token value generator.
+         Default: org.apache.oltu.oauth2.as.issuer.UUIDValueGenerator
+         Applicable values: org.apache.oltu.oauth2.as.issuer.UUIDValueGenerator,
+                            org.apache.oltu.oauth2.as.issuer.MD5Generator,
+                            org.wso2.carbon.identity.oauth.tokenvaluegenerator.SHA256Generator-->
+    <!--<AccessTokenValueGenerator>org.wso2.carbon.identity.oauth.tokenvaluegenerator.SHA256Generator</AccessTokenValueGenerator>-->
+
+    <!-- This configuration is used to specify whether the Service Provider tenant domain should be used when generating
+         access token. Otherwise user domain will be used. Currently this value is only supported by the JWTTokenIssuer.-->
+    <!--<UseSPTenantDomain>True</UseSPTenantDomain>-->
+
+    <!--
+        Default values for OAuth1RequestTokenUrl, OAuth1AccessTokenUrl, OAuth1AuthorizeUrl
+        OAuth2AuthzEPUrl, OAuth2TokenEPUrl and OAuth2UserInfoEPUrl are built in following format
+        https://<HostName>:<MgtTrpProxyPort except 443>/<ProxyContextPath>/<context>/<path>
+        If above format doesn't satisfy uncomment the following configs and explicitly configure the values
+     -->
+    <OAuth1RequestTokenUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth/request-token</OAuth1RequestTokenUrl>
+    <OAuth1AuthorizeUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth/authorize-url</OAuth1AuthorizeUrl>
+    <OAuth1AccessTokenUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth/access-token</OAuth1AccessTokenUrl>
+    <OAuth2AuthzEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/authorize</OAuth2AuthzEPUrl>
+    <OAuth2TokenEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/token</OAuth2TokenEPUrl>
+    <OAuth2RevokeEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/revoke</OAuth2RevokeEPUrl>
+    <OAuth2IntrospectEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/introspect</OAuth2IntrospectEPUrl>
+    <OAuth2UserInfoEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/userinfo</OAuth2UserInfoEPUrl>
+    <OIDCCheckSessionEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oidc/checksession</OIDCCheckSessionEPUrl>
+    <OIDCLogoutEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oidc/logout</OIDCLogoutEPUrl>
+    <OAuth2ConsentPage>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/oauth2_authz.do</OAuth2ConsentPage>
+    <OAuth2ErrorPage>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/oauth2_error.do</OAuth2ErrorPage>
+    <OIDCConsentPage>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/oauth2_consent.do</OIDCConsentPage>
+    <OIDCLogoutConsentPage>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/oauth2_logout_consent.do</OIDCLogoutConsentPage>
+    <OIDCLogoutPage>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/oauth2_logout.do</OIDCLogoutPage>
+
+    <OIDCWebFingerEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/.well-known/webfinger</OIDCWebFingerEPUrl>
+
+    <!-- For tenants below urls will be modified as https://<hostname>:<port>/t/<tenant domain>/<path>-->
+    <OAuth2DCREPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/api/identity/oauth2/dcr/v1.0/register</OAuth2DCREPUrl>
+    <OAuth2JWKSPage>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/jwks</OAuth2JWKSPage>
+    <OIDCDiscoveryEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/oidcdiscovery</OIDCDiscoveryEPUrl>
+
+    <!-- Default validity period for Authorization Code in seconds -->
+    <AuthorizationCodeDefaultValidityPeriod>300</AuthorizationCodeDefaultValidityPeriod>
+    <!-- Default validity period for application access tokens in seconds -->
+    <AccessTokenDefaultValidityPeriod>3600</AccessTokenDefaultValidityPeriod>
+    <!-- Default validity period for user access tokens in seconds -->
+    <UserAccessTokenDefaultValidityPeriod>3600</UserAccessTokenDefaultValidityPeriod>
+    <!-- Validity period for refresh token -->
+    <RefreshTokenValidityPeriod>84600</RefreshTokenValidityPeriod>
+    <!-- Timestamp skew in seconds -->
+    <TimestampSkew>0</TimestampSkew>
+    <!-- Enable renewal of refresh token for refresh_token grant -->
+    <RenewRefreshTokenForRefreshGrant>true</RenewRefreshTokenForRefreshGrant>
+    <!-- Process the token before storing it in database, e.g. encrypting -->
+    <TokenPersistenceProcessor>org.wso2.carbon.identity.oauth.tokenprocessor.PlainTextPersistenceProcessor</TokenPersistenceProcessor>
+    <!-- This should be true if the oauth keys (consumer secret, access token, refresh token and authorization code) need to be hashed,
+         before storing them in the database. If the value is false, the oauth keys will be saved in a plain text format.
+         By default : false.
+         Supported versions: IS 5.6.0 onwards.
+    -->
+    <EnableClientSecretHash>false</EnableClientSecretHash>
+    <!-- If the user is a federated, user will not be able to access claims from local userstore even if the username matches -->
+    <MapFederatedUsersToLocal>false</MapFederatedUsersToLocal>
+    <!-- Supported Response Types -->
+    <SupportedResponseTypes>
+        <SupportedResponseType>
+            <ResponseTypeName>token</ResponseTypeName>
+            <ResponseTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.authz.handlers.TokenResponseTypeHandler</ResponseTypeHandlerImplClass>
+        </SupportedResponseType>
+        <SupportedResponseType>
+            <ResponseTypeName>code</ResponseTypeName>
+            <ResponseTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.authz.handlers.CodeResponseTypeHandler</ResponseTypeHandlerImplClass>
+        </SupportedResponseType>
+        <SupportedResponseType>
+            <ResponseTypeName>id_token</ResponseTypeName>
+            <ResponseTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.authz.handlers.TokenResponseTypeHandler</ResponseTypeHandlerImplClass>
+        </SupportedResponseType>
+        <SupportedResponseType>
+            <ResponseTypeName>id_token token</ResponseTypeName>
+            <ResponseTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.authz.handlers.TokenResponseTypeHandler</ResponseTypeHandlerImplClass>
+        </SupportedResponseType>
+    </SupportedResponseTypes>
+    <!-- Supported Grant Types -->
+    <SupportedGrantTypes>
+        <SupportedGrantType>
+            <GrantTypeName>authorization_code</GrantTypeName>
+            <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.token.handlers.grant.AuthorizationCodeGrantHandler</GrantTypeHandlerImplClass>
+        </SupportedGrantType>
+        <SupportedGrantType>
+            <GrantTypeName>password</GrantTypeName>
+            <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.token.handlers.grant.PasswordGrantHandler</GrantTypeHandlerImplClass>
+        </SupportedGrantType>
+        <SupportedGrantType>
+            <GrantTypeName>refresh_token</GrantTypeName>
+            <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler</GrantTypeHandlerImplClass>
+        </SupportedGrantType>
+        <SupportedGrantType>
+            <GrantTypeName>client_credentials</GrantTypeName>
+            <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.token.handlers.grant.ClientCredentialsGrantHandler</GrantTypeHandlerImplClass>
+            <IsRefreshTokenAllowed>false</IsRefreshTokenAllowed>
+            <IdTokenAllowed>false</IdTokenAllowed>
+        </SupportedGrantType>
+        <SupportedGrantType>
+            <GrantTypeName>urn:ietf:params:oauth:grant-type:saml2-bearer</GrantTypeName>
+            <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.token.handlers.grant.saml.SAML2BearerGrantHandler</GrantTypeHandlerImplClass>
+        </SupportedGrantType>
+        <SupportedGrantType>
+            <GrantTypeName>iwa:ntlm</GrantTypeName>
+            <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.token.handlers.grant.iwa.ntlm.NTLMAuthenticationGrantHandler</GrantTypeHandlerImplClass>
+        </SupportedGrantType>
+        <SupportedGrantType>
+            <GrantTypeName>urn:ietf:params:oauth:grant-type:jwt-bearer</GrantTypeName>
+            <GrantTypeHandlerImplClass>org.wso2.carbon.identity.oauth2.grant.jwt.JWTBearerGrantHandler</GrantTypeHandlerImplClass>
+            <GrantTypeValidatorImplClass>org.wso2.carbon.identity.oauth2.grant.jwt.JWTGrantValidator</GrantTypeValidatorImplClass>
+        </SupportedGrantType>
+    </SupportedGrantTypes>
+
+    <!--
+        Defines the grant types that will filter user claims based on user consent in their responses such as
+        id_token or user info response.
+
+        Default grant types that filter user claims based on user consent are 'authorization_code' and 'implicit'.
+
+        Supported versions: IS 5.5.0 onwards.
+    -->
+    <UserConsentEnabledGrantTypes>
+        <UserConsentEnabledGrantType>
+            <GrantTypeName>authorization_code</GrantTypeName>
+        </UserConsentEnabledGrantType>
+        <UserConsentEnabledGrantType>
+            <GrantTypeName>implicit</GrantTypeName>
+        </UserConsentEnabledGrantType>
+    </UserConsentEnabledGrantTypes>
+
+    <OAuthCallbackHandlers>
+        <OAuthCallbackHandler Class="org.wso2.carbon.identity.oauth.callback.DefaultCallbackHandler"/>
+    </OAuthCallbackHandlers>
+    <TokenValidators>
+        <TokenValidator type="bearer" class="org.wso2.carbon.identity.oauth2.validators.DefaultOAuth2TokenValidator"/>
+        <TokenValidator type="jwt" class="org.wso2.carbon.identity.oauth2.validators.OAuth2JWTTokenValidator"/>
+    </TokenValidators>
+
+    <!-- Scope validators list. The validators registered here wil be executed during token validation. -->
+    <ScopeValidators>
+        <ScopeValidator class="org.wso2.carbon.identity.oauth2.validators.JDBCScopeValidator" />
+        <ScopeValidator class="org.wso2.carbon.identity.oauth2.validators.xacml.XACMLScopeValidator"/>
+    </ScopeValidators>
+
+    <!-- Scope handlers list. The handlers registered here will be executed at the scope validation phase while
+         issuing access tokens. -->
+    <ScopeHandlers>
+        <ScopeHandler class="org.wso2.carbon.identity.oauth2.validators.OIDCScopeHandler" />
+    </ScopeHandlers>
+
+    <!-- Assertions can be used to embedd parameters into access token. -->
+    <EnableAssertions>
+        <UserName>false</UserName>
+    </EnableAssertions>
+
+
+    <!-- This should be true if subject identifier in the token validation response needs to adhere to the
+    following SP configuration.
+
+    - Use tenant domain in local subject identifier.
+    - Use user store domain in local subject identifier.
+
+    if the value is false, subject identifier will be set as the fully qualified username.
+
+    Default value : false
+
+    Supported versions: IS 5.4.0 beta onwards
+    -->
+    <!--<BuildSubjectIdentifierFromSPConfig>true</BuildSubjectIdentifierFromSPConfig>-->
+
+    <!-- This should be set to true when using multiple user stores and keys
+        should saved into different tables according to the user store. By default
+        all the application keys are saved in to the same table. UserName Assertion
+        should be 'true' to use this. -->
+    <EnableAccessTokenPartitioning>false</EnableAccessTokenPartitioning>
+    <!-- user store domain names and mapping to new table name. eg: if you
+        provide 'A:foo.com', foo.com should be the user store domain name and 'A'
+        represent the relavant mapping of token store table, i.e. tokens will be
+        added to a table called IDN_OAUTH2_ACCESS_TOKEN_A. -->
+    <AccessTokenPartitioningDomains><!-- A:foo.com, B:bar.com --></AccessTokenPartitioningDomains>
+    <AuthorizationContextTokenGeneration>
+        <Enabled>false</Enabled>
+        <TokenGeneratorImplClass>org.wso2.carbon.identity.oauth2.authcontext.JWTTokenGenerator</TokenGeneratorImplClass>
+        <ClaimsRetrieverImplClass>org.wso2.carbon.identity.oauth2.authcontext.DefaultClaimsRetriever</ClaimsRetrieverImplClass>
+        <ConsumerDialectURI>http://wso2.org/claims</ConsumerDialectURI>
+        <SignatureAlgorithm>SHA256withRSA</SignatureAlgorithm>
+        <AuthorizationContextTTL>15</AuthorizationContextTTL>
+    </AuthorizationContextTokenGeneration>
+
+    <SAML2Grant>
+        <!--SAML2TokenHandler></SAML2TokenHandler-->
+        <!-- UserType conifg decides whether the SAML assertion carrying user is local user or a federated user.
+        Only Local Users can access claims from local userstore. LEGACY users will have to have tenant domain appended username.
+        They will not be able to access claims from local userstore. To get claims by mapping users with exact same username from local
+        userstore (for non LOCAL scenarios) use mapFederatedUsersToLocal config -->
+        <!--<UserType>LOCAL</UserType>-->
+        <UserType>FEDERATED</UserType>
+        <!--UserType>LEGACY</UserType-->
+    </SAML2Grant>
+
+    <OpenIDConnect>
+        <IDTokenBuilder>org.wso2.carbon.identity.openidconnect.DefaultIDTokenBuilder</IDTokenBuilder>
+        <SignatureAlgorithm>SHA256withRSA</SignatureAlgorithm>
+
+        <!-- Default asymmetric encryption algorithm that used to encrypt CEK. -->
+        <IDTokenEncryptionAlgorithm>RSA-OAEP</IDTokenEncryptionAlgorithm>
+        <!-- Default symmetric encryption algorithm that used to encrypt JWT claims set. -->
+        <IDTokenEncryptionMethod>A128GCM</IDTokenEncryptionMethod>
+
+        <!-- Supported versions: IS 5.5.0 onwards. -->
+        <SupportedIDTokenEncryptionAlgorithms>
+            <SupportedIDTokenEncryptionAlgorithm>RSA1_5</SupportedIDTokenEncryptionAlgorithm>
+            <SupportedIDTokenEncryptionAlgorithm>RSA-OAEP</SupportedIDTokenEncryptionAlgorithm>
+        </SupportedIDTokenEncryptionAlgorithms>
+        <SupportedIDTokenEncryptionMethods>
+            <SupportedIDTokenEncryptionMethod>A128GCM</SupportedIDTokenEncryptionMethod>
+            <SupportedIDTokenEncryptionMethod>A192GCM</SupportedIDTokenEncryptionMethod>
+            <SupportedIDTokenEncryptionMethod>A256GCM</SupportedIDTokenEncryptionMethod>
+            <SupportedIDTokenEncryptionMethod>A128CBC-HS256</SupportedIDTokenEncryptionMethod>
+            <SupportedIDTokenEncryptionMethod>A128CBC+HS256</SupportedIDTokenEncryptionMethod>
+        </SupportedIDTokenEncryptionMethods>
+
+        <EnableAudiences>true</EnableAudiences>
+        <!-- Comment out to add Audience values to the JWT token (id_token)  -->
+        <!--Audiences>
+               <Audience>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/token</Audience>
+        </Audiences -->
+
+        <!--
+            Default value for IDTokenIssuerID, is OAuth2TokenEPUrl.
+            If that doesn't satisfy uncomment the following config and explicitly configure the value
+        -->
+        <IDTokenIssuerID>${carbon.protocol}://${carbon.host}:${carbon.management.port}/oauth2/token</IDTokenIssuerID>
+        <IDTokenCustomClaimsCallBackHandler>org.wso2.carbon.identity.openidconnect.SAMLAssertionClaimsCallback</IDTokenCustomClaimsCallBackHandler>
+        <IDTokenExpiration>3600</IDTokenExpiration>
+        <UserInfoJWTSignatureAlgorithm>SHA256withRSA</UserInfoJWTSignatureAlgorithm>
+        <UserInfoEndpointClaimRetriever>org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoUserStoreClaimRetriever</UserInfoEndpointClaimRetriever>
+        <UserInfoEndpointRequestValidator>org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInforRequestDefaultValidator</UserInfoEndpointRequestValidator>
+        <UserInfoEndpointAccessTokenValidator>org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoISAccessTokenValidator</UserInfoEndpointAccessTokenValidator>
+        <UserInfoEndpointResponseBuilder>org.wso2.carbon.identity.oauth.endpoint.user.impl.UserInfoJSONResponseBuilder</UserInfoEndpointResponseBuilder>
+        <SkipUserConsent>false</SkipUserConsent>
+        <!-- Sign the ID Token with Service Provider Tenant Private Key-->
+        <SignJWTWithSPKey>false</SignJWTWithSPKey>
+        <!--
+            Expiry period of the logout token used in OIDC Back Channel Logout in seconds.
+            Supported versions: IS 5.5.0 onwards
+        -->
+        <LogoutTokenExpiration>120</LogoutTokenExpiration>
+
+        <!--
+            OIDC Request Object builder implementation.
+            Supported versions: IS 5.4.0 onwards
+        -->
+        <RequestObjectBuilders>
+            <RequestObjectBuilder>
+                <Type>request_param_value_builder</Type>
+                <ClassName>org.wso2.carbon.identity.openidconnect.RequestParamRequestObjectBuilder</ClassName>
+            </RequestObjectBuilder>
+        </RequestObjectBuilders>
+
+        <!--
+            OIDC Request Object validator implementation.
+            Supported versions: IS 5.4.0 onwards
+        -->
+        <RequestObjectValidator>org.wso2.carbon.identity.openidconnect.RequestObjectValidatorImpl</RequestObjectValidator>
+    </OpenIDConnect>
+
+    <!-- Configs related to OAuth2 token persistence -->
+    <TokenPersistence>
+        <Enable>true</Enable>
+        <PoolSize>0</PoolSize>
+        <RetryCount>5</RetryCount>
+    </TokenPersistence>
+</OAuth>
+
+<MultifactorAuthentication>
+    <!--Enable>false</Enable-->
+    <XMPPSettings>
+        <XMPPConfig>
+            <XMPPProvider>gtalk</XMPPProvider>
+            <XMPPServer>talk.google.com</XMPPServer>
+            <XMPPPort>5222</XMPPPort>
+            <XMPPExt>gmail.com</XMPPExt>
+            <XMPPUserName>multifactor1@gmail.com</XMPPUserName>
+            <XMPPPassword>wso2carbon</XMPPPassword>
+        </XMPPConfig>
+    </XMPPSettings>
+</MultifactorAuthentication>
+
+<SSOService>
+    <EntityId>${carbon.host}</EntityId>
+    <!--
+        Default value for IdentityProviderURL is  built in following format
+        https://<HostName>:<MgtTrpProxyPort except 443>/<ProxyContextPath>/samlsso
+        If that doesn't satisfy uncomment the following config and explicitly configure the value
+    -->
+    <IdentityProviderURL>${carbon.protocol}://${carbon.host}:${carbon.management.port}/samlsso</IdentityProviderURL>
+    <DefaultLogoutEndpoint>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/samlsso_logout.do</DefaultLogoutEndpoint>
+    <NotificationEndpoint>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/samlsso_notification.do</NotificationEndpoint>
+    <SingleLogoutRetryCount>5</SingleLogoutRetryCount>
+    <SingleLogoutRetryInterval>60000</SingleLogoutRetryInterval>
+    <!-- in milli seconds -->
+    <TenantPartitioningEnabled>false</TenantPartitioningEnabled>
+    <AttributesClaimDialect>http://wso2.org/claims</AttributesClaimDialect>
+    <!--<SAMLSSOAssertionBuilder>org.wso2.carbon.identity.sso.saml.builders.assertion.ExtendedDefaultAssertionBuilder</SAMLSSOAssertionBuilder>-->
+    <SAMLSSOAssertionBuilder>org.wso2.carbon.identity.sso.saml.builders.assertion.DefaultSAMLAssertionBuilder</SAMLSSOAssertionBuilder>
+    <SAMLSSOEncrypter>org.wso2.carbon.identity.sso.saml.builders.encryption.DefaultSSOEncrypter</SAMLSSOEncrypter>
+    <SAMLSSOSigner>org.wso2.carbon.identity.sso.saml.builders.signature.DefaultSSOSigner</SAMLSSOSigner>
+    <SAML2HTTPRedirectSignatureValidator>org.wso2.carbon.identity.sso.saml.validators.SAML2HTTPRedirectDeflateSignatureValidator</SAML2HTTPRedirectSignatureValidator>
+    <!--SAMLSSOResponseBuilder>org.wso2.carbon.identity.sso.saml.builders.DefaultResponseBuilder</SAMLSSOResponseBuilder-->
+
+    <!-- SAML Token validity period in minutes -->
+    <SAMLResponseValidityPeriod>5</SAMLResponseValidityPeriod>
+    <UseAuthenticatedUserDomainCrypto>false</UseAuthenticatedUserDomainCrypto>
+    <SAMLDefaultSigningAlgorithmURI>http://www.w3.org/2000/09/xmldsig#rsa-sha1</SAMLDefaultSigningAlgorithmURI>
+    <SAMLDefaultDigestAlgorithmURI>http://www.w3.org/2000/09/xmldsig#sha1</SAMLDefaultDigestAlgorithmURI>
+    <SAMLDefaultAssertionEncryptionAlgorithmURI>http://www.w3.org/2001/04/xmlenc#aes256-cbc</SAMLDefaultAssertionEncryptionAlgorithmURI>
+    <SAMLDefaultKeyEncryptionAlgorithmURI>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</SAMLDefaultKeyEncryptionAlgorithmURI>
+    <SLOHostNameVerificationEnabled>true</SLOHostNameVerificationEnabled>
+</SSOService>
+
+<Consent>
+    <!--Specify whether consent management should be enable during SSO.-->
+    <EnableSSOConsentManagement>true</EnableSSOConsentManagement>
+</Consent>
+
+<SecurityTokenService>
+    <!--
+        Default value for IdentityProviderURL is  built in following format
+        https://<HostName>:<MgtTrpProxyPort except 443>/<ProxyContextPath>/services/wso2carbon-sts
+        If that doesn't satisfy uncomment the following config and explicitly configure the value
+    -->
+    <IdentityProviderURL>${carbon.protocol}://${carbon.host}:${carbon.management.port}/services/wso2carbon-sts</IdentityProviderURL>
+</SecurityTokenService>
+
+<PassiveSTS>
+    <!--
+        Default value for IdentityProviderURL is  built in following format
+        https://<HostName>:<MgtTrpProxyPort except 443>/<ProxyContextPath>/passivests
+        If that doesn't satisfy uncomment the following config and explicitly configure the value
+    -->
+    <IdentityProviderURL>${carbon.protocol}://${carbon.host}:${carbon.management.port}/passivests</IdentityProviderURL>
+    <RetryURL>${carbon.protocol}://${carbon.host}:${carbon.management.port}/authenticationendpoint/retry.do</RetryURL>
+    <TokenStoreClassName>org.wso2.carbon.identity.sts.passive.utils.NoPersistenceTokenStore</TokenStoreClassName>
+    <SLOHostNameVerificationEnabled>true</SLOHostNameVerificationEnabled>
+</PassiveSTS>
+
+<EntitlementSettings>
+    <ThirftBasedEntitlementConfig>
+        <EnableThriftService>false</EnableThriftService>
+        <ReceivePort>${Ports.ThriftEntitlementReceivePort}</ReceivePort>
+        <ClientTimeout>10000</ClientTimeout>
+        <KeyStore>
+            <Location>${carbon.home}/repository/resources/security/wso2carbon.jks</Location>
+            <Password>wso2carbon</Password>
+        </KeyStore>
+        <!-- Enable this element to mention the host-name of your IS machine -->
+        <ThriftHostName>${carbon.host}</ThriftHostName>
+    </ThirftBasedEntitlementConfig>
+</EntitlementSettings>
+
+<SCIM>
+    <!--
+        Default value for UserEPUrl and GroupEPUrl are built in following format
+        https://<HostName>:<MgtTrpProxyPort except 443>/<ProxyContextPath>/<context>/<path>
+        If that doesn't satisfy uncomment the following config and explicitly configure the value
+    -->
+    <UserEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/wso2/scim/Users</UserEPUrl>
+    <GroupEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/wso2/scim/Groups</GroupEPUrl>
+    <SCIMAuthenticators>
+        <Authenticator class="org.wso2.carbon.identity.scim.provider.auth.BasicAuthHandler">
+            <Property name="Priority">5</Property>
+        </Authenticator>
+        <Authenticator class="org.wso2.carbon.identity.scim.provider.auth.OAuthHandler">
+            <Property name="Priority">10</Property>
+            <Property name="AuthorizationServer">local://services</Property>
+            <!--Property name="AuthorizationServer">${carbon.protocol}://${carbon.host}:${carbon.management.port}/services</Property>
+            <Property name="UserName">admin</Property>
+            <Property name="Password">admin</Property-->
+        </Authenticator>
+
+        <!-- Flag to indicate advanced complex multiValued attributes support enabled or not.
+        Default value : false
+        Supported versions: IS 5.5.0 beta onwards
+        -->
+        <!--<ComplexMultiValuedAttributeSupportEnabled>true</ComplexMultiValuedAttributeSupportEnabled>-->
+    </SCIMAuthenticators>
+</SCIM>
+
+<SCIM2>
+    <!--
+        Default value for UserEPUrl and GroupEPUrl are built in following format
+        https://<HostName>:<MgtTrpProxyPort except 443>/<ProxyContextPath>/<context>/<path>
+        If that doesn't satisfy uncomment the following config and explicitly configure the value
+    -->
+    <!--UserEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/scim2/Users</UserEPUrl-->
+    <!--GroupEPUrl>${carbon.protocol}://${carbon.host}:${carbon.management.port}/scim2/Groups</GroupEPUrl-->
+</SCIM2>
+
+<!--Recovery>
+    <Notification>
+        <Password>
+            <Enable>false</Enable>
+        </Password>
+        <Username>
+            <Enable>false</Enable>
+        </Username>
+        <InternallyManage>true</InternallyManage>
+   </Notification>
+   <Question>
+        <Password>
+            <Enable>false</Enable>
+            <NotifyStart>false</NotifyStart>
+            <Separator>!</Separator>
+            <MinAnswers>2</MinAnswers>
+            <ReCaptcha>
+                <Enable>true</Enable>
+                <MaxFailedAttempts>2</MaxFailedAttempts>
+            </ReCaptcha>
+        </Password>
+    </Question>
+    <ExpiryTime>1440</ExpiryTime>
+    <NotifySuccess>false</NotifySuccess>
+    <AdminPasswordReset>
+        <Offline>false</Offline>
+        <OTP>false</OTP>
+        <RecoveryLink>false</RecoveryLink>
+    </AdminPasswordReset>
+</Recovery>
+
+<EmailVerification>
+    <Enable>false</Enable>
+  <ExpiryTime>1440</ExpiryTime>
+    <LockOnCreation>true</LockOnCreation>
+    <Notification>
+        <InternallyManage>true</InternallyManage>
+    </Notification>
+    <AskPassword>
+      <ExpiryTime>1440</ExpiryTime>
+      <PasswordGenerator>org.wso2.carbon.user.mgt.common.DefaultPasswordGenerator</PasswordGenerator>
+    </AskPassword>
+</EmailVerification>
+
+<SelfRegistration>
+    <Enable>false</Enable>
+    <LockOnCreation>true</LockOnCreation>
+    <Notification>
+        <InternallyManage>true</InternallyManage>
+    </Notification>
+    <ReCaptcha>true</ReCaptcha>
+<VerificationCode>
+  <ExpiryTime>1440</ExpiryTime>
+</VerificationCode>
+</SelfRegistration-->
+
+<EnableAskPasswordAdminUI>true</EnableAskPasswordAdminUI>
+
+<EnableRecoveryEndpoint>true</EnableRecoveryEndpoint>
+<EnableSelfSignUpEndpoint>true</EnableSelfSignUpEndpoint>
+
+<AuthenticationPolicy>
+    <CheckAccountExist>true</CheckAccountExist>
+</AuthenticationPolicy>
+
+<EventListeners>
+    <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                   name="org.wso2.carbon.user.mgt.workflow.userstore.UserStoreActionListener"
+                   orderId="10" enable="true"/>
+    <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                   name="org.wso2.carbon.identity.mgt.IdentityMgtEventListener"
+                   orderId="50" enable="false"/>
+    <!-- Enable the following SCIM 1.1 event listener and disable the SCIM2 event listener if SCIM 1.1 is
+    used. -->
+    <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                   name="org.wso2.carbon.identity.scim.common.listener.SCIMUserOperationListener"
+                   orderId="90" enable="false"/>
+    <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                   name="org.wso2.carbon.identity.scim2.common.listener.SCIMUserOperationListener"
+                   orderId="93" enable="true"/>
+    <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                   name="org.wso2.carbon.identity.governance.listener.IdentityMgtEventListener"
+                   orderId="95" enable="true"/>
+    <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener" name="org.wso2.carbon.identity.governance.listener.IdentityStoreEventListener"
+                   orderId="97" enable="true">
+        <Property name="Data.Store">org.wso2.carbon.identity.governance.store.JDBCIdentityDataStore</Property>
+    </EventListener>
+    <EventListener type="org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler"
+                   name="org.wso2.carbon.identity.data.publisher.application.authentication.impl.DASLoginDataPublisherImpl"
+                   orderId="10" enable="false"/>
+    <EventListener type="org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler"
+                   name="org.wso2.carbon.identity.data.publisher.application.authentication.impl.DASSessionDataPublisherImpl"
+                   orderId="11" enable="false"/>
+    <EventListener type="org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler"
+                   name="org.wso2.carbon.identity.data.publisher.application.authentication.AuthnDataPublisherProxy"
+                   orderId="11" enable="true"/>
+
+    <!-- Enable this listener to call DeleteEventRecorders. -->
+    <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                   name="org.wso2.carbon.user.mgt.listeners.UserDeletionEventListener"
+                   orderId="98" enable="false"/>
+    <EventListener type="org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+                   name="org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.consent.ConsentMgtPostAuthnHandler"
+                   orderId="110" enable="true"/>
+
+    <!-- Audit Loggers -->
+
+    <!-- Old Audit Logger -->
+    <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                   name="org.wso2.carbon.user.mgt.listeners.UserMgtAuditLogger"
+                   orderId="0" enable="false"/>
+
+    <!-- New Audit Loggers-->
+    <EventListener type="org.wso2.carbon.user.core.listener.UserOperationEventListener"
+                   name="org.wso2.carbon.user.mgt.listeners.UserManagementAuditLogger"
+                   orderId="1" enable="true"/>
+    <EventListener type="org.wso2.carbon.user.core.listener.UserManagementErrorEventListener"
+                   name="org.wso2.carbon.user.mgt.listeners.UserMgtFailureAuditLogger"
+                   orderId="0" enable="true"/>
+</EventListeners>
+
+<!-- These recorders are used to write user delete information to specific sources. Default event recorder is CSV
+ file recorder. This recorder is disabled by default. Enable it by setting enable="true". To run these recorders,
+ EventListener "rg.wso2.carbon.user.mgt.listeners.UserDeletionEventListener" also should be enabled. Which is
+ also disabled by default. -->
+<UserDeleteEventRecorders>
+    <UserDeleteEventRecorder name="org.wso2.carbon.user.mgt.recorder.DefaultUserDeletionEventRecorder" enable="false">
+        <!-- Un comment below line if you need to write entries to a separate .csv file. Otherwise this will be
+        written in to a log file using a separate appender. -->
+        <!--<Property name="path">${carbon.home}/repository/logs/delete-records.csv</Property>-->
+    </UserDeleteEventRecorder>
+</UserDeleteEventRecorders>
+
+<CacheConfig>
+    <!-- Identity cache configuration.
+         Timeouts are in seconds.
+         Capacity is the maximum cache size.
+         Unless specifically mentioned, you do not need to set the isDistributed flag.
+     -->
+    <CacheManager name="IdentityApplicationManagementCacheManager">
+        <Cache name="AppAuthFrameworkSessionContextCache"
+                                                 enable="true" timeout="300" capacity="5000" isDistributed="false"/>
+        <Cache name="AuthenticationContextCache" enable="true" timeout="300" capacity="5000" isDistributed="false"/>
+        <Cache name="AuthenticationRequestCache" enable="true" timeout="300" capacity="5000" isDistributed="false"/>
+        <Cache name="AuthenticationResultCache"  enable="true" timeout="300" capacity="5000" isDistributed="false"/>
+        <Cache name="AppInfoCache"               enable="true"  timeout="900" capacity="5000" isDistributed="false"/>
+        <Cache name="AuthorizationGrantCache"    enable="true" timeout="300" capacity="5000" isDistributed="false"/>
+        <Cache name="OAuthCache"                 enable="true" timeout="300" capacity="5000" isDistributed="false"/>
+        <Cache name="OAuthScopeCache"            enable="true"  timeout="300" capacity="5000" isDistributed="false"/>
+        <Cache name="OAuthSessionDataCache"      enable="true" timeout="300" capacity="5000" isDistributed="false"/>
+        <Cache name="SAMLSSOParticipantCache"    enable="true" timeout="300" capacity="5000" isDistributed="false"/>
+        <Cache name="SAMLSSOSessionIndexCache"   enable="true" timeout="300" capacity="5000" isDistributed="false"/>
+        <Cache name="SAMLSSOSessionDataCache"    enable="true" timeout="300" capacity="5000" isDistributed="false"/>
+        <Cache name="ServiceProviderCache"       enable="true"  timeout="900" capacity="5000" isDistributed="false"/>
+        <Cache name="ProvisioningConnectorCache" enable="true"  timeout="900" capacity="5000" isDistributed="false"/>
+        <Cache name="ProvisioningEntityCache"    enable="true" timeout="900" capacity="5000" isDistributed="false"/>
+        <Cache name="ServiceProviderProvisioningConnectorCache" enable="true"  timeout="900" capacity="5000" isDistributed="false"/>
+        <Cache name="IdPCacheByAuthProperty"     enable="true"  timeout="900" capacity="5000" isDistributed="false"/>
+        <Cache name="IdPCacheByHRI"              enable="true"  timeout="900" capacity="5000" isDistributed="false"/>
+        <Cache name="IdPCacheByName"             enable="true"  timeout="900" capacity="5000" isDistributed="false"/>
+    </CacheManager>
+</CacheConfig>
+
+<!--Cookies>
+    <Cookie name="commonAuthId" domain="localhost" httpOnly="true" secure="true" />
+</Cookies-->
+
+
+<ResourceAccessControl>
+    <Resource context="(.*)/api/identity/user/v1.0/validate-code" secured="true" http-method="all"/>
+    <Resource context="(.*)/api/identity/user/v1.0/resend-code" secured="true" http-method="all"/>
+    <Resource context="(.*)/api/identity/user/v1.0/me" secured="true" http-method="POST"/>
+    <Resource context="(.*)/api/identity/user/v1.0/me" secured="true" http-method="GET"/>
+    <Resource context="(.*)/api/identity/user/v1.0/pi-info" secured="true" http-method="all">
+        <Permissions>/permission/admin/manage/identity/usermgt/view</Permissions>
+    </Resource>
+    <Resource context="(.*)/api/identity/user/v1.0/pi-info/(.*)" secured="true" http-method="all">
+        <Permissions>/permission/admin/manage/identity/usermgt/view</Permissions>
+    </Resource>
+
+    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents" secured="true" http-method="all"/>
+    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/receipts/(.*)" secured="true" http-method="all"/>
+
+    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/purposes" secured="true" http-method="POST">
+        <Permissions>/permission/admin/manage/identity/consentmgt/add</Permissions>
+    </Resource>
+    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/purposes(.*)" secured="true" http-method="GET"/>
+    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/purposes(.+)" secured="true" http-method="DELETE">
+        <Permissions>/permission/admin/manage/identity/consentmgt/delete</Permissions>
+    </Resource>
+
+    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/pii-categories" secured="true" http-method="POST">
+        <Permissions>/permission/admin/manage/identity/consentmgt/add</Permissions>
+    </Resource>
+    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/pii-categories(.*)" secured="true" http-method="GET"/>
+    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/pii-categories(.+)" secured="true" http-method="DELETE">
+        <Permissions>/permission/admin/manage/identity/consentmgt/delete</Permissions>
+    </Resource>
+
+    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/purpose-categories" secured="true" http-method="POST">
+        <Permissions>/permission/admin/manage/identity/consentmgt/add</Permissions>
+    </Resource>
+    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/purpose-categories(.*)" secured="true" http-method="GET"/>
+    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/purpose-categories(.+)" secured="true" http-method="DELETE">
+        <Permissions>/permission/admin/manage/identity/consentmgt/delete</Permissions>
+    </Resource>
+
+    <Resource context="(.*)/api/identity/recovery/(.*)" secured="true" http-method="all"/>
+    <Resource context="(.*)/.well-known(.*)" secured="true" http-method="all"/>
+    <Resource context="(.*)/api/identity/oauth2/dcr/v1.0/register(.*)" secured="true" http-method="POST">
+        <Permissions>/permission/admin/manage/identity/applicationmgt/create</Permissions>
+    </Resource>
+    <Resource context="(.*)/api/identity/oauth2/dcr/v1.0/register(.*)" secured="true" http-method="DELETE">
+        <Permissions>/permission/admin/manage/identity/applicationmgt/delete</Permissions>
+    </Resource>
+    <Resource context="(.*)/api/identity/oauth2/dcr/v1.0/register(.*)" secured="true" http-method="PUT">
+        <Permissions>/permission/admin/manage/identity/applicationmgt/update</Permissions>
+    </Resource>
+    <Resource context="(.*)/api/identity/oauth2/dcr/v1.0/register(.*)" secured="true" http-method="GET">
+        <Permissions>/permission/admin/manage/identity/applicationmgt/view</Permissions>
+    </Resource>
+    <Resource context="(.*)/identity/register(.*)" secured="true" http-method="all">
+        <Permissions>/permission/admin/manage/identity/applicationmgt/delete</Permissions>
+    </Resource>
+    <Resource context="(.*)/identity/connect/register(.*)" secured="true" http-method="all">
+        <Permissions>/permission/admin/manage/identity/applicationmgt/create</Permissions>
+    </Resource>
+    <Resource context="(.*)/oauth2/introspect(.*)" secured="true" http-method="all">
+        <Permissions>/permission/admin/manage/identity/applicationmgt/view</Permissions>
+    </Resource>
+    <Resource context="(.*)/api/identity/entitlement/(.*)" secured="true" http-method="all">
+        <Permissions>/permission/admin/manage/identity/pep</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Users" secured="true" http-method="POST">
+        <Permissions>/permission/admin/manage/identity/usermgt/create</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Users" secured="true" http-method="GET">
+        <Permissions>/permission/admin/manage/identity/usermgt/list</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Groups" secured="true" http-method="POST">
+        <Permissions>/permission/admin/manage/identity/rolemgt/create</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Groups" secured="true" http-method="GET">
+        <Permissions>/permission/admin/manage/identity/rolemgt/view</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Users/(.*)" secured="true" http-method="GET">
+        <Permissions>/permission/admin/manage/identity/usermgt/view</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Users/(.*)" secured="true" http-method="PUT">
+        <Permissions>/permission/admin/manage/identity/usermgt/update</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Users/(.*)" secured="true" http-method="PATCH">
+        <Permissions>/permission/admin/manage/identity/usermgt/update</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Users/(.*)" secured="true" http-method="DELETE">
+        <Permissions>/permission/admin/manage/identity/usermgt/delete</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Groups/(.*)" secured="true" http-method="GET">
+        <Permissions>/permission/admin/manage/identity/rolemgt/view</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Groups/(.*)" secured="true" http-method="PUT">
+        <Permissions>/permission/admin/manage/identity/rolemgt/update</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Groups/(.*)" secured="true" http-method="PATCH">
+        <Permissions>/permission/admin/manage/identity/rolemgt/update</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Groups/(.*)" secured="true" http-method="DELETE">
+        <Permissions>/permission/admin/manage/identity/rolemgt/delete</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Me" secured="true"    http-method="GET">
+        <Permissions>/permission/admin/login</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Me" secured="true" http-method="DELETE">
+        <Permissions>/permission/admin/manage/identity/usermgt/delete</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Me" secured="true"    http-method="PUT">
+        <Permissions>/permission/admin/login</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Me" secured="true"   http-method="PATCH">
+        <Permissions>/permission/admin/login</Permissions>
+    </Resource>
+    <Resource context="(.*)/scim2/Me" secured="true" http-method="POST">
+        <Permissions>/permission/admin/manage/identity/usermgt/create</Permissions>
+    </Resource>
+    <Resource context="/scim2/ServiceProviderConfig" secured="false" http-method="all">
+        <Permissions></Permissions>
+    </Resource>
+    <Resource context="/scim2/ResourceType" secured="false" http-method="all">
+        <Permissions></Permissions>
+    </Resource>
+    <Resource context="/scim2/Bulk" secured="true"  http-method="all">
+        <Permissions>/permission/admin/manage/identity/usermgt</Permissions>
+    </Resource>
+    <Resource context="(.*)/api/identity/oauth2/dcr/(.*)" secured="true" http-method="all">
+        <Permissions>/permission/admin/manage/identity/applicationmgt</Permissions>
+    </Resource>
+
+    <Resource context="(.*)/api/identity/oauth2/uma/resourceregistration/v1.0/(.*)" secured="true" http-method="all"/>
+    <Resource context="(.*)/api/identity/oauth2/uma/permission/v1.0/(.*)" secured="true" http-method="all"/>
+</ResourceAccessControl>
+
+<ClientAppAuthentication>
+    <Application name="dashboard" hash="66cd9688a2ae068244ea01e70f0e230f5623b7fa4cdecb65070a09ec06452262"/>
+</ClientAppAuthentication>
+
+<TenantContextsToRewrite>
+    <WebApp>
+        <Context>/api/identity/user/v1.0/</Context>
+        <Context>/api/identity/consent-mgt/v1.0/</Context>
+        <Context>/api/identity/recovery/v0.9/</Context>
+        <Context>/oauth2/</Context>
+        <Context>/scim2/</Context>
+        <Context>/api/identity/entitlement/</Context>
+        <Context>/api/identity/oauth2/dcr/v1.0/</Context>
+    </WebApp>
+    <Servlet>
+        <Context>/identity/(.*)</Context>
+    </Servlet>
+</TenantContextsToRewrite>
+
+<!-- Server Synchronization Tolerance Configuration in seconds -->
+<ClockSkew>300</ClockSkew>
+
+<!-- JWT validator configurations -->
+<JWTValidatorConfigs>
+    <Enable>true</Enable>
+    <JWKSEndpoint>
+        <HTTPConnectionTimeout>1000</HTTPConnectionTimeout>
+        <HTTPReadTimeout>1000</HTTPReadTimeout>
+        <HTTPSizeLimit>51200</HTTPSizeLimit>
+    </JWKSEndpoint>
+</JWTValidatorConfigs>
+
+<AdaptiveAuth>
+    <EventPublisher>
+        <receiverURL>http://localhost:8280/</receiverURL>
+    </EventPublisher>
+    <AsyncSequenceExecutorPoolSize>5</AsyncSequenceExecutorPoolSize>
+</AdaptiveAuth>
+
+</Server>

--- a/modules/wso2is/templates/repository/conf/registry.xml.erb
+++ b/modules/wso2is/templates/repository/conf/registry.xml.erb
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+<wso2registry>
+
+    <!--
+    For details on configuring different config & governance registries see;
+    http://wso2.org/library/tutorials/2010/04/sharing-registry-space-across-multiple-product-instances
+    -->
+
+    <currentDBConfig>localregistry</currentDBConfig>
+    <readOnly>false</readOnly>
+    <enableCache>true</enableCache>
+    <registryRoot>/</registryRoot>
+
+    <dbConfig name="localregistry">
+        <dataSource>jdbc/WSO2CarbonDB</dataSource>
+    </dbConfig>
+
+    <dbConfig name="sharedregistry">
+        <dataSource><%= @wso2_reg_db['jndi_config'] %></dataSource>
+    </dbConfig>
+
+    <remoteInstance url="https://localhost:9443/registry">
+        <id>sharedregistry</id>
+        <dbConfig>sharedregistry</dbConfig>
+        <readOnly>false</readOnly>
+        <registryRoot>/</registryRoot>
+        <enableCache>true</enableCache>
+        <cacheId><%= @wso2_reg_db['url'] %></cacheId>
+    </remoteInstance>
+
+    <mount path="/_system/config" overwrite="true">
+        <instanceId>sharedregistry</instanceId>
+        <targetPath>/_system/config</targetPath>
+    </mount>
+
+    <mount path="/_system/governance" overwrite="true">
+        <instanceId>sharedregistry</instanceId>
+        <targetPath>/_system/governance</targetPath>
+    </mount>
+
+   <handler class="org.wso2.carbon.identity.entitlement.policy.finder.registry.RegistryPolicyHandler">
+        <filter class="org.wso2.carbon.identity.entitlement.policy.finder.registry.RegistryPolicyMediaTypeMatcher">
+            <property name="mediaType">application/xacml-policy+xml</property>
+        </filter>
+    </handler>
+
+    <!-- <currentDBConfig>wso2registry</currentDBConfig>
+<readOnly>false</readOnly>
+<enableCache>true</enableCache>
+<registryRoot>/</registryRoot>
+
+<dbConfig name="wso2registry">
+    <dataSource>jdbc/WSO2CarbonDB</dataSource>
+</dbConfig>
+
+<handler class="org.wso2.carbon.identity.entitlement.policy.finder.registry.RegistryPolicyHandler">
+<filter class="org.wso2.carbon.identity.entitlement.policy.finder.registry.RegistryPolicyMediaTypeMatcher">
+<property name="mediaType">application/xacml-policy+xml</property>
+</filter>
+</handler> -->
+
+ <!--<handler class="org.wso2.carbon.registry.extensions.handlers.SynapseRepositoryHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/vnd.apache.synapse</property>
+        </filter>
+    </handler>
+    <handler class="org.wso2.carbon.registry.extensions.handlers.SynapseRepositoryHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/vnd.apache.esb</property>
+        </filter>
+    </handler>
+    <handler class="org.wso2.carbon.registry.extensions.handlers.Axis2RepositoryHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/vnd.apache.axis2</property>
+        </filter>
+    </handler>
+    <handler class="org.wso2.carbon.registry.extensions.handlers.Axis2RepositoryHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/vnd.apache.wsas</property>
+        </filter>
+    </handler>
+    <handler class="org.wso2.carbon.registry.extensions.handlers.WSDLMediaTypeHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/wsdl+xml</property>
+        </filter>
+    </handler>
+    <handler class="org.wso2.carbon.registry.extensions.handlers.XSDMediaTypeHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+            <property name="mediaType">application/x-xsd+xml</property>
+        </filter>
+    </handler> -->
+
+    <!--remoteInstance url="https://localhost:9443/registry">
+        <id>instanceid</id>
+        <username>username</username>
+        <password>password</password>
+    </remoteInstance-->
+
+    <!--remoteInstance url="https://localhost:9443/registry">
+        <id>instanceid</id>
+        <dbConfig>wso2registry</dbConfig>
+        <readOnly>false</readOnly>
+        <enableCache>true</enableCache>
+        <registryRoot>/</registryRoot>
+    </remoteInstance-->
+
+    <!--mount path="/_system/config" overwrite="true|false|virtual">
+        <instanceId>instanceid</instanceId>
+        <targetPath>/_system/nodes</targetPath>
+    </mount-->
+
+    <indexingConfiguration>
+        <startIndexing>false</startIndexing>
+        <startingDelayInSeconds>35</startingDelayInSeconds>
+        <indexingFrequencyInSeconds>5</indexingFrequencyInSeconds>
+        <!--number of resources submit for given indexing thread -->
+        <batchSize>40</batchSize>
+        <!--number of worker threads for indexing -->
+        <indexerPoolSize>40</indexerPoolSize>
+        <!-- location storing the time the indexing took place-->
+        <lastAccessTimeLocation>/_system/local/repository/components/org.wso2.carbon.registry/indexing/lastaccesstime</lastAccessTimeLocation>
+        <!-- the indexers that implement the indexer interface for a relevant media type/(s) -->
+        <indexers>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.MSExcelIndexer" mediaTypeRegEx="application/vnd.ms-excel"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.MSPowerpointIndexer" mediaTypeRegEx="application/vnd.ms-powerpoint"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.MSWordIndexer" mediaTypeRegEx="application/msword"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.PDFIndexer" mediaTypeRegEx="application/pdf"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.XMLIndexer" mediaTypeRegEx="application/xml"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.XMLIndexer" mediaTypeRegEx="application/(.)+\+xml"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.PlainTextIndexer" mediaTypeRegEx="application/swagger\+json"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.PlainTextIndexer" mediaTypeRegEx="application/(.)+\+json"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.PlainTextIndexer" mediaTypeRegEx="text/(.)+"/>
+            <indexer class="org.wso2.carbon.registry.indexing.indexer.PlainTextIndexer" mediaTypeRegEx="application/x-javascript"/>
+        </indexers>
+        <exclusions>
+            <exclusion pathRegEx="/_system/config/repository/dashboards/gadgets/swfobject1-5/.*[.]html"/>
+            <exclusion pathRegEx="/_system/local/repository/components/org[.]wso2[.]carbon[.]registry/mount/.*"/>
+        </exclusions>
+    </indexingConfiguration>
+
+
+    <versionResourcesOnChange>false</versionResourcesOnChange>
+
+    <!-- NOTE: You can edit the options under "StaticConfiguration" only before the
+     startup. -->
+    <staticConfiguration>
+        <versioningProperties>true</versioningProperties>
+        <versioningComments>true</versioningComments>
+        <versioningTags>true</versioningTags>
+        <versioningRatings>true</versioningRatings>
+    </staticConfiguration>
+</wso2registry>

--- a/modules/wso2is/templates/repository/conf/security/authenticators.xml.erb
+++ b/modules/wso2is/templates/repository/conf/security/authenticators.xml.erb
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!--
+  ~ Copyright 2005-2011 WSO2, Inc. (http://wso2.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+     This is the configuration file for Carbon authenticators. All the authenticator related configurations
+     should go here.
+-->
+<Authenticators xmlns="http://wso2.org/projects/carbon/authenticators.xml">
+
+    <!-- Authenticator Configurations for TokenUIAuthenticator -->
+    <Authenticator name="TokenUIAuthenticator" disabled="true">
+        <Priority>5</Priority>
+    </Authenticator>
+
+    <!-- Authenticator Configurations for SAML2SSOAuthenticator -->
+    <Authenticator name="SAML2SSOAuthenticator" disabled="true">
+        <Priority>10</Priority>
+        <Config>
+            <Parameter name="LoginPage">/carbon/admin/login.jsp</Parameter>
+            <Parameter name="ServiceProviderID">carbonServer</Parameter>
+            <Parameter name="IdentityProviderSSOServiceURL">https://localhost:9443/samlsso</Parameter>
+            <Parameter name="NameIDPolicyFormat">urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</Parameter>
+            <Parameter name="AssertionConsumerServiceURL">https://localhost:9443/acs</Parameter>
+
+            <!-- <Parameter name="IdPCertAlias">wso2carbon</Parameter> -->
+            <!-- <Parameter name="ResponseSignatureValidationEnabled">false</Parameter> -->
+            <!-- <Parameter name="AssertionSignatureValidationEnabled">false</Parameter> -->
+            <!-- <Parameter name="LoginAttributeName"></Parameter> -->
+            <!-- <Parameter name="RoleClaimAttribute"></Parameter> -->
+            <!-- <Parameter name="AttributeValueSeparator">,</Parameter> -->
+
+            <!-- <Parameter name="JITUserProvisioningEnabled">true</Parameter> -->
+            <!-- <Parameter name="ProvisioningDefaultUserstore">PRIMARY</Parameter> -->
+            <!-- <Parameter name="ProvisioningDefaultRole">admin</Parameter> -->
+            <!-- <Parameter name="IsSuperAdminRoleRequired">true</Parameter> -->
+	</Config>
+
+	<!-- If this authenticator should skip any URI from authentication, specify it under "SkipAuthentication"
+	<SkipAuthentication>
+            <UrlContains></UrlContains>
+        </SkipAuthentication> -->
+
+	<!-- If this authenticator should skip any URI from session validation, specify it under "SkipAuthentication
+        <SkipSessionValidation>
+            <UrlContains></UrlContains>
+        </SkipSessionValidation> -->
+    </Authenticator>
+
+        <!-- Authenticator Configurations for MutualSSLAuthenticator -->
+    <Authenticator name="MutualSSLAuthenticator">
+	  <Priority>5</Priority>
+	  <Config>
+	      <Parameter name="UsernameHeader">UserName</Parameter>
+	      <Parameter name="WhiteListEnabled">false</Parameter>
+	      <Parameter name="WhiteList"/>
+	  </Config>
+    </Authenticator>
+
+</Authenticators>

--- a/modules/wso2is/templates/repository/conf/tomcat/catalina-server.xml.erb
+++ b/modules/wso2is/templates/repository/conf/tomcat/catalina-server.xml.erb
@@ -1,0 +1,147 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<% if @enable_secure_vault %>
+<Server xmlns:svns="http://org.wso2.securevault/configuration" port="8005" shutdown="SHUTDOWN">
+<%- else -%>
+<Server port="8005" shutdown="SHUTDOWN">
+<% end %>
+
+    <Service className="org.wso2.carbon.tomcat.ext.service.ExtendedStandardService" name="Catalina">
+
+        <!--
+        optional attributes:
+
+        proxyPort="80"
+        -->
+        <Connector  protocol="org.apache.coyote.http11.Http11NioProtocol"
+                port="9763"
+		<%- if @ports['proxyPort'] and @ports['proxyPort']['http'] -%>
+                proxyPort="<%= @ports['proxyPort']['http'] %>"
+                <%- end -%>
+                redirectPort="9443"
+                bindOnInit="false"
+                maxHttpHeaderSize="8192"
+                acceptorThreadCount="2"
+                maxThreads="<%= @tomcat['maxThreads'] %>"
+                minSpareThreads="50"
+                disableUploadTimeout="false"
+                connectionUploadTimeout="120000"
+                maxKeepAliveRequests="200"
+                acceptCount="<%= @tomcat['acceptCount'] %>"
+                server="WSO2 Carbon Server"
+                compression="on"
+                compressionMinSize="2048"
+                noCompressionUserAgents="gozilla, traviata"
+                compressableMimeType="text/html,text/javascript,application/x-javascript,application/javascript,application/xml,text/css,application/xslt+xml,text/xsl,image/gif,image/jpg,image/jpeg"
+                URIEncoding="UTF-8"/>
+
+    <!--
+	optional attributes:
+
+        proxyPort="443"
+        Added sslEnabledProtocols="TLSv1,TLSv1.1,TLSv1.2" for poodle vulnerability fix
+        -->
+        <% if @enable_secure_vault %>
+        <Connector protocol="org.apache.coyote.http11.Http11NioProtocol"
+                   port="9443"
+                   <%- if @ports['proxyPort'] and @ports['proxyPort']['https'] -%>
+                   proxyPort="<%= @ports['proxyPort']['https'] %>"
+                   <%- end -%>
+                   bindOnInit="false"
+                   sslProtocol="TLS"
+                   sslEnabledProtocols="TLSv1,TLSv1.1,TLSv1.2"
+                   maxHttpHeaderSize="8192"
+                   acceptorThreadCount="2"
+                   maxThreads="<%= @tomcat['maxThreads'] %>"
+                   minSpareThreads="50"
+                   disableUploadTimeout="false"
+                   enableLookups="false"
+                   connectionUploadTimeout="120000"
+                   maxKeepAliveRequests="200"
+                   acceptCount="<%= @tomcat['acceptCount'] %>"
+                   server="WSO2 Carbon Server"
+                   clientAuth="want"
+                   compression="on"
+                   scheme="https"
+                   secure="true"
+                   SSLEnabled="true"
+                   compressionMinSize="2048"
+                   noCompressionUserAgents="gozilla, traviata"
+                   compressableMimeType="text/html,text/javascript,application/x-javascript,application/javascript,application/xml,text/css,application/xslt+xml,text/xsl,image/gif,image/jpg,image/jpeg"
+    				       keystoreFile="${carbon.home}/<%= @key_stores['connector_key_store']['location'] %>"
+				           keystorePass="password"
+                   URIEncoding="UTF-8"
+                   svns:secretAlias="Server.Service.Connector.keystorePass"/>
+        <%- else -%>
+        <Connector protocol="org.apache.coyote.http11.Http11NioProtocol"
+                   port="9443"
+                   <%- if @ports['proxyPort'] and @ports['proxyPort']['https'] -%>
+                   proxyPort="<%= @ports['proxyPort']['https'] %>"
+                   <%- end -%>
+                   bindOnInit="false"
+                   sslProtocol="TLS"
+                   sslEnabledProtocols="TLSv1,TLSv1.1,TLSv1.2"
+                   maxHttpHeaderSize="8192"
+                   acceptorThreadCount="2"
+                   maxThreads="250"
+                   minSpareThreads="50"
+                   disableUploadTimeout="false"
+                   enableLookups="false"
+                   connectionUploadTimeout="120000"
+                   maxKeepAliveRequests="200"
+                   acceptCount="200"
+                   server="WSO2 Carbon Server"
+                   clientAuth="want"
+                   compression="on"
+                   scheme="https"
+                   secure="true"
+                   SSLEnabled="true"
+                   compressionMinSize="2048"
+                   noCompressionUserAgents="gozilla, traviata"
+                   compressableMimeType="text/html,text/javascript,application/x-javascript,application/javascript,application/xml,text/css,application/xslt+xml,text/xsl,image/gif,image/jpg,image/jpeg"
+    				       keystoreFile="${carbon.home}/<%= @key_stores['connector_key_store']['location'] %>"
+				           keystorePass="<%= @key_stores['connector_key_store']['password'] %>"
+                   URIEncoding="UTF-8"/>
+        <% end %>
+
+
+        <Engine name="Catalina" defaultHost="localhost">
+
+            <!--Realm className="org.apache.catalina.realm.MemoryRealm" pathname="${carbon.home}/repository/conf/tomcat/tomcat-users.xml"/-->
+
+            <Realm className="org.wso2.carbon.tomcat.ext.realms.CarbonTomcatRealm"/>
+
+            <Host name="localhost" unpackWARs="true" deployOnStartup="false" autoDeploy="false"
+                  appBase="${carbon.home}/repository/deployment/server/webapps/">
+
+                <Valve className="org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve"/>
+                <Valve className="org.apache.catalina.valves.AccessLogValve" directory="${carbon.home}/repository/logs"
+                       prefix="http_access_" suffix=".log"
+                       pattern="combined"/>
+                <Valve className="org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve" threshold="600"/>
+                <Valve className="org.wso2.carbon.tomcat.ext.valves.CompositeValve"/>
+
+                <!-- Authentication and Authorization valve for the rest apis and we can configure context for this in identity.xml  -->
+                <Valve className="org.wso2.carbon.identity.auth.valve.AuthenticationValve"/>
+                <Valve className="org.wso2.carbon.identity.authz.valve.AuthorizationValve"/>
+                <Valve className="org.wso2.carbon.identity.context.rewrite.valve.TenantContextRewriteValve"/>
+            </Host>
+        </Engine>
+    </Service>
+</Server>

--- a/modules/wso2is/templates/repository/conf/user-mgt.xml.erb
+++ b/modules/wso2is/templates/repository/conf/user-mgt.xml.erb
@@ -1,0 +1,269 @@
+<!--
+  ~ Copyright WSO2, Inc. (http://wso2.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<UserManager>
+    <Realm>
+        <Configuration>
+        <AddAdmin>true</AddAdmin>
+            <AdminRole>admin</AdminRole>
+            <AdminUser>
+                <UserName>admin</UserName>
+                <Password>admin</Password>
+            </AdminUser>
+            <EveryOneRoleName>everyone</EveryOneRoleName> <!-- By default users in this role sees the registry root -->
+            <Property name="isCascadeDeleteEnabled">true</Property>
+            <Property name="initializeNewClaimManager">true</Property>
+            <Property name="dataSource"><%= @wso2_user_db['jndi_config'] %></Property>
+        </Configuration>
+        <Configuration>
+<!-- <AddAdmin>true</AddAdmin>
+    <AdminRole>admin</AdminRole>
+    <AdminUser>
+        <UserName>admin</UserName>
+        <Password>admin</Password>
+    </AdminUser>
+    <EveryOneRoleName>everyone</EveryOneRoleName> <! By default users in this role sees the registry root -->
+    <!-- <Property name="isCascadeDeleteEnabled">true</Property>
+<Property name="initializeNewClaimManager">true</Property>
+    <Property name="dataSource">jdbc/WSO2CarbonDB</Property>
+</Configuration> -->
+
+	    <!-- Following is the configuration for internal JDBC user store. This user store manager is based on JDBC.
+	         In case if application needs to manage passwords externally set property
+	         <Property name="PasswordsExternallyManaged">true</Property>.
+	         In case if user core cache domain is needed to identify uniquely set property
+	         <Property name="UserCoreCacheIdentifier">domain</Property>.
+	         Furthermore properties, IsEmailUserName and DomainCalculation are readonly properties.
+	         Note: Do not comment within UserStoreManager tags. Cause, specific tag names are used as tokens
+	         when building configurations for products.
+	    -->
+        <UserStoreManager class="org.wso2.carbon.user.core.jdbc.JDBCUserStoreManager">
+            <Property name="TenantManager">org.wso2.carbon.user.core.tenant.JDBCTenantManager</Property>
+            <Property name="driverName">"<%= @wso2_user_db['driver_class_name'] %>"</Property>
+            <Property name="url">"<%= @wso2_user_db['url'] %>"</Property>
+            <Property name="userName">wso2carbon</Property>
+            <Property encrypted="false" name="password">wso2carbon</Property>
+            <Property name="ReadOnly">false</Property>
+            <Property name="ReadGroups">true</Property>
+            <Property name="WriteGroups">true</Property>
+            <Property name="UsernameJavaRegEx">^[\S]{3,30}$</Property>
+            <Property name="UsernameJavaScriptRegEx">^[\S]{3,30}$</Property>
+            <Property name="UsernameJavaRegExViolationErrorMsg">Username pattern policy violated</Property>
+            <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
+            <Property name="PasswordJavaScriptRegEx">^[\S]{5,30}$</Property>
+            <Property name="PasswordJavaRegExViolationErrorMsg">Password length should be within 5 to 30 characters</Property>
+            <Property name="RolenameJavaRegEx">^[\S]{3,30}$</Property>
+            <Property name="RolenameJavaScriptRegEx">^[\S]{3,30}$</Property>
+            <Property name="CaseInsensitiveUsername">false</Property>
+            <Property name="SCIMEnabled">false</Property>
+            <Property name="IsBulkImportSupported">false</Property>
+            <Property name="PasswordDigest">SHA-256</Property>
+            <Property name="StoreSaltedPassword">true</Property>
+            <Property name="MultiAttributeSeparator">,</Property>
+            <Property name="MaxUserNameListLength">100</Property>
+            <Property name="MaxRoleNameListLength">100</Property>
+            <Property name="UserRolesCacheEnabled">true</Property>
+            <Property name="UserNameUniqueAcrossTenants">false</Property>
+        </UserStoreManager>
+
+	    <!-- If product is using an external LDAP as the user store in READ ONLY mode, use following user manager.
+		     In case if user core cache domain is needed to identify uniquely set property
+		     <Property name="UserCoreCacheIdentifier">domain</Property>
+ 	    -->
+        <!--UserStoreManager class="org.wso2.carbon.user.core.ldap.ReadOnlyLDAPUserStoreManager">
+            <Property name="TenantManager">org.wso2.carbon.user.core.tenant.CommonHybridLDAPTenantManager</Property>
+            <Property name="ConnectionURL">ldap://localhost:10389</Property>
+            <Property name="ConnectionName">uid=admin,ou=system</Property>
+            <Property name="ConnectionPassword">admin</Property>
+            <Property name="AnonymousBind">false</Property>
+            <Property name="UserSearchBase">ou=system</Property>
+            <Property name="UserNameAttribute">uid</Property>
+            <Property name="UserNameSearchFilter">(&amp;(objectClass=person)(uid=?))</Property>
+            <Property name="UserNameListFilter">(objectClass=person)</Property>
+            <Property name="DisplayNameAttribute"/>
+            <Property name="ReadGroups">true</Property>
+            <Property name="GroupSearchBase">ou=system</Property>
+            <Property name="GroupNameAttribute">cn</Property>
+            <Property name="GroupNameSearchFilter">(&amp;(objectClass=groupOfNames)(cn=?))</Property>
+            <Property name="GroupNameListFilter">(objectClass=groupOfNames)</Property>
+            <Property name="MembershipAttribute">member</Property>
+            <Property name="BackLinksEnabled">false</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
+            <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
+            <Property name="SCIMEnabled">false</Property>
+            <Property name="PasswordHashMethod">PLAIN_TEXT</Property>
+            <Property name="MultiAttributeSeparator">,</Property>
+            <Property name="MaxUserNameListLength">100</Property>
+            <Property name="MaxRoleNameListLength">100</Property>
+            <Property name="UserRolesCacheEnabled">true</Property>
+            <Property name="ConnectionPoolingEnabled">true</Property>
+            <Property name="LDAPConnectionTimeout">5000</Property>
+            <Property name="ReadTimeout"/>
+            <Property name="RetryAttempts"/>
+            <Property name="ReplaceEscapeCharactersAtUserLogin">true</Property>
+        </UserStoreManager-->
+
+	    <!-- Active directory configuration is as follows.
+	         In case if user core cache domain is needed to identify uniquely set property
+	         <Property name="UserCoreCacheIdentifier">domain</Property>
+	         There are few special properties for "Active Directory".
+	         They are :
+	         1.Referral - (comment out this property if this feature is not reuired) This enables LDAP referral support.
+	         2.BackLinksEnabled - (Do not comment, set to true or false) In some cases LDAP works with BackLinksEnabled.
+	         In which role is stored at user level. Depending on this value we need to change the Search Base within code.
+	         isADLDSRole - (Do not comment) Set to true if connecting to an AD LDS instance else set to false.
+	    -->
+        <!--UserStoreManager class="org.wso2.carbon.user.core.ldap.ActiveDirectoryUserStoreManager">
+            <Property name="TenantManager">org.wso2.carbon.user.core.tenant.CommonHybridLDAPTenantManager</Property>
+            <Property name="ConnectionURL">ldaps://10.100.1.100:636</Property>
+            <Property name="ConnectionName">CN=admin,CN=Users,DC=WSO2,DC=Com</Property>
+            <Property name="ConnectionPassword">A1b2c3d4</Property>
+            <Property name="AnonymousBind">false</Property>
+            <Property name="UserSearchBase">CN=Users,DC=WSO2,DC=Com</Property>
+            <Property name="UserEntryObjectClass">user</Property>
+            <Property name="UserNameAttribute">cn</Property>
+            <Property name="UserNameSearchFilter">(&amp;(objectClass=user)(cn=?))</Property>
+            <Property name="UserNameListFilter">(objectClass=user)</Property>
+            <Property name="DisplayNameAttribute"/>
+            <Property name="ReadGroups">true</Property>
+            <Property name="WriteGroups">true</Property>
+            <Property name="GroupSearchBase">CN=Users,DC=WSO2,DC=Com</Property>
+            <Property name="GroupEntryObjectClass">group</Property>
+            <Property name="GroupNameAttribute">cn</Property>
+            <Property name="GroupNameSearchFilter">(&amp;(objectClass=group)(cn=?))</Property>
+            <Property name="GroupNameListFilter">(objectcategory=group)</Property>
+            <Property name="MembershipAttribute">member</Property>
+            <Property name="MemberOfAttribute">memberOf</Property>
+            <Property name="BackLinksEnabled">true</Property>
+            <Property name="Referral">follow</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
+            <Property name="UsernameJavaScriptRegEx">^[\S]{3,30}$</Property>
+            <Property name="UsernameJavaRegExViolationErrorMsg">Username pattern policy violated</Property>
+            <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
+            <Property name="PasswordJavaScriptRegEx">^[\S]{5,30}$</Property>
+            <Property name="PasswordJavaRegExViolationErrorMsg">Password length should be within 5 to 30 characters</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
+            <Property name="RolenameJavaScriptRegEx">^[\S]{3,30}$</Property>
+            <Property name="SCIMEnabled">false</Property>
+            <Property name="IsBulkImportSupported">false</Property>
+            <Property name="EmptyRolesAllowed">true</Property>
+            <Property name="PasswordHashMethod">PLAIN_TEXT</Property>
+            <Property name="MultiAttributeSeparator">,</Property>
+            <Property name="isADLDSRole">false</Property>
+            <Property name="userAccountControl">512</Property>
+            <Property name="MaxUserNameListLength">100</Property>
+            <Property name="MaxRoleNameListLength">100</Property>
+            <Property name="MembershipAttributeRange">1500</Property>
+            <Property name="kdcEnabled">false</Property>
+            <Property name="defaultRealmName">WSO2.ORG</Property>
+            <Property name="UserRolesCacheEnabled">true</Property>
+            <Property name="ConnectionPoolingEnabled">false</Property>
+            <Property name="LDAPConnectionTimeout">5000</Property>
+            <Property name="ReadTimeout"/>
+            <Property name="RetryAttempts"/>
+        </UserStoreManager-->
+
+        <!-- Following user manager is used by Identity Server (IS) as its default user manager.
+             IS will do token replacement when building the product. Therefore do not change the syntax.
+             If "kdcEnabled" parameter is true, IS will allow service principle management.
+             Thus "ServicePasswordJavaRegEx", "ServiceNameJavaRegEx" properties control the service name format and
+             service password formats. In case if user core cache domain is needed to identify uniquely set property
+             <Property name="UserCoreCacheIdentifier">domain</Property>
+        -->
+        <!--UserStoreManager class="org.wso2.carbon.user.core.ldap.ReadWriteLDAPUserStoreManager">
+            <Property name="TenantManager">org.wso2.carbon.user.core.tenant.CommonHybridLDAPTenantManager</Property>
+            <Property name="ConnectionURL">ldap://localhost:${Ports.EmbeddedLDAP.LDAPServerPort}</Property>
+            <Property name="ConnectionName">uid=admin,ou=system</Property>
+            <Property name="ConnectionPassword">admin</Property>
+            <Property name="AnonymousBind">false</Property>
+            <Property name="UserSearchBase">ou=Users,dc=wso2,dc=org</Property>
+            <Property name="UserEntryObjectClass">identityPerson</Property>
+            <Property name="UserNameAttribute">uid</Property>
+            <Property name="UserNameSearchFilter">(&amp;(objectClass=person)(uid=?))</Property>
+            <Property name="UserNameListFilter">(objectClass=person)</Property>
+            <Property name="DisplayNameAttribute"/>
+            <Property name="ReadGroups">true</Property>
+            <Property name="WriteGroups">true</Property>
+            <Property name="GroupSearchBase">ou=Groups,dc=wso2,dc=org</Property>
+            <Property name="GroupEntryObjectClass">groupOfNames</Property>
+            <Property name="GroupNameAttribute">cn</Property>
+            <Property name="GroupNameSearchFilter">(&amp;(objectClass=groupOfNames)(cn=?))</Property>
+            <Property name="GroupNameListFilter">(objectClass=groupOfNames)</Property>
+            <Property name="MembershipAttribute">member</Property>
+            <Property name="BackLinksEnabled">false</Property>
+            <Property name="UsernameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
+            <Property name="UsernameJavaScriptRegEx">^[\S]{3,30}$</Property>
+            <Property name="UsernameJavaRegExViolationErrorMsg">Username pattern policy violated</Property>
+            <Property name="PasswordJavaRegEx">^[\S]{5,30}$</Property>
+            <Property name="PasswordJavaScriptRegEx">^[\S]{5,30}$</Property>
+            <Property name="PasswordJavaRegExViolationErrorMsg">Password length should be within 5 to 30 characters</Property>
+            <Property name="RolenameJavaRegEx">[a-zA-Z0-9._\-|//]{3,30}$</Property>
+            <Property name="RolenameJavaScriptRegEx">^[\S]{3,30}$</Property>
+            <Property name="SCIMEnabled">true</Property>
+            <Property name="IsBulkImportSupported">false</Property>
+            <Property name="EmptyRolesAllowed">true</Property>
+            <Property name="PasswordHashMethod">PLAIN_TEXT</Property>
+            <Property name="MultiAttributeSeparator">,</Property>
+            <Property name="MaxUserNameListLength">100</Property>
+            <Property name="MaxRoleNameListLength">100</Property>
+            <Property name="kdcEnabled">false</Property>
+            <Property name="defaultRealmName">WSO2.ORG</Property>
+            <Property name="UserRolesCacheEnabled">true</Property>
+            <Property name="ConnectionPoolingEnabled">false</Property>
+            <Property name="LDAPConnectionTimeout">5000</Property>
+            <Property name="ReadTimeout"/>
+            <Property name="RetryAttempts"/>
+        </UserStoreManager-->
+
+        <AuthorizationManager class="org.wso2.carbon.user.core.authorization.JDBCAuthorizationManager">
+            <Property name="AdminRoleManagementPermissions">/permission</Property>
+            <Property name="AuthorizationCacheEnabled">true</Property>
+            <Property name="GetAllRolesOfUserEnabled">false</Property>
+        </AuthorizationManager>
+    </Realm>
+</UserManager>
+
+<!--
+************* Description of some of the configuration properties used in user-mgt.xml *********************************
+DomainName -
+    This property must be used by all secondary user store managers in multiple user store configuration.
+    DomainName is a unique identifier given to the user store. Users must provide both the domain name and
+    username at log-in as "DomainName\Username"
+UserRolesCacheEnabled -
+    This is to indicate whether to cache role list of a user. By default it is set to true.
+    You may need to disable it if user-roles are changed by external means and need to reflect
+    those changes in the carbon product immediately.
+ReplaceEscapeCharactersAtUserLogin -
+    This is to configure whether escape characters in user name needs to be replaced at user login.
+    Currently the identified escape characters that needs to be replaced are '\' & '\\'
+UserDNPattern -
+    This property will be used when authenticating users. During authentication we do a bind. But if the user is login
+    with email address or some other property we need to first lookup LDAP and retrieve DN for the user.
+    This involves an additional step.  If UserDNPattern is specified the DN will be constructed using the pattern
+    specified in this property. Performance of this is much better than looking up DN and binding user.
+RoleDNPattern -
+    This property will be used when checking whether user has been assigned to a given role.
+    Rather than searching the role in search base, by using this property direct search can be done.
+PasswordHashMethod -
+    This says how the password should be stored. Allowed values are as follows,
+        SHA - Uses SHA digest method
+        MD5 - Uses MD 5 digest method
+        PLAIN_TEXT - Plain text passwords
+        In addition to above this supports all digest methods supported by http://docs.oracle.com/javase/6/docs/api/java/security/MessageDigest.html.
+DisplayNameAttribute -
+    This is to have a dedicated LDAP attribute to display an entity(User/Role) in UI, in addition to the UserNameAttribute which is used for IS-UserStore interactions.
+-->

--- a/modules/wso2is/templates/wso2is.erb
+++ b/modules/wso2is/templates/wso2is.erb
@@ -1,0 +1,173 @@
+#!/bin/bash
+#----------------------------------------------------------------------------
+#  Copyright (c) 2018 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#----------------------------------------------------------------------------
+#
+# /etc/init.d/as
+# chkconfig:         2345 90 10
+# description:       wso2 service init script.
+# Provides:          wso2 Inc
+# Required-Start:    $syslog
+# Should-Start:
+# Required-Stop:     $syslog
+# Should-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description:  wso2 service #
+# Get function from functions library
+if [ -f /etc/init.d/functions ]; then
+      . /etc/init.d/functions
+  else
+      . /lib/lsb/init-functions
+fi
+
+
+#set the configuration settings for the service
+USER="ubuntu"
+PRODUCT_CODE="wso2is"
+CARBON_HOME="<%=@install_path%>"
+LOCK_FILE="<%=@install_path%>/wso2carbon.lck"
+PID_FILE="<%=@install_path%>/wso2carbon.pid"
+CMD="<%=@install_path%>/bin/wso2server.sh"
+
+#Get the status details of the service
+status() {
+     if [ -f $PID_FILE ]; then
+        PID=`cat $PID_FILE`
+        ps -fp $PID > /dev/null 2>&1
+        PIDVAL=$?
+     else
+        PIDVAL=3
+     fi
+
+     if [ $PIDVAL -eq 0 ]; then
+        echo "WSO2 $PRODUCT_CODE server is running ..."
+     else
+        echo "WSO2 $PRODUCT_CODE server is stopped."
+     fi
+     echo
+     return $PIDVAL
+}
+
+#Start the service
+start() {
+     if [ -f $PID_FILE ]; then
+        PID=`cat $PID_FILE`
+        ps -fp $PID > /dev/null 2>&1
+        PIDVAL=$?
+     else
+        PIDVAL=3
+     fi
+
+     if [ $PIDVAL -eq 0 ]; then
+        echo "WSO2 $PRODUCT_CODE server is running ..."
+     else
+        echo -n "Starting WSO2 $PRODUCT_CODE server: "
+        touch $LOCK_FILE
+        su - $USER -c "$CMD start > /dev/null 2>&1 &"
+        sleep 5
+        if [ -f $PID_FILE ]; then
+            PID=`cat $PID_FILE`
+            ps -fp $PID > /dev/null 2>&1
+            PIDVAL=$?
+            if [ $PIDVAL -eq 0 ]; then
+                echo "[Ok]"
+            else
+                echo "[Fail]"
+            fi
+        else
+            echo "[Fail]"
+            PIDVAL=2
+        fi
+     fi
+     echo
+     return $PIDVAL
+}
+
+#Restart the service
+restart() {
+    echo -n "Restarting WSO2 $PRODUCT_CODE server: "
+    touch $LOCK_FILE
+    su - $USER -c "$CMD restart > /dev/null 2>&1 &"
+    sleep 15
+    if [ -f $PID_FILE ]; then
+        PID=`cat $PID_FILE`
+        ps -fp $PID > /dev/null 2>&1
+        PIDVAL=$?
+        if [ $PIDVAL -eq 0 ]; then
+            echo "[Ok]"
+        else
+            echo "[Fail]"
+        fi
+    else
+        echo "[Fail]"
+        PIDVAL=2
+    fi
+    echo
+    return $PIDVAL
+}
+
+#Stop the service
+stop() {
+    if [ -f $PID_FILE ]; then
+        PID=`cat $PID_FILE`
+        ps -fp $PID > /dev/null 2>&1
+        PIDVAL=$?
+        if [ $PIDVAL -eq 0 ]; then
+            echo -n "Stopping WSO2 $PRODUCT_CODE server: "
+            su - $USER -c "$CMD stop > /dev/null 2>&1 &"
+            rm -f $LOCK_FILE
+            sleep 10
+            PID=`cat $PID_FILE`
+            ps -fp $PID > /dev/null 2>&1
+            PIDVAL=$?
+            if [ $PIDVAL -eq 0 ]; then
+                echo "[Fail]"
+                PIDVAL=2
+            else
+                echo "[Ok]"
+                PIDVAL=0
+            fi
+         else
+            echo "WSO2 $PRODUCT_CODE server is not running."
+            PIDVAL=0
+         fi
+    else
+         echo "WSO2 $PRODUCT_CODE server is not running."
+         PIDVAL=0
+    fi
+    echo
+    return $PIDVAL
+}
+
+###Main logic of the service###
+case "$1" in
+start)
+  start
+  ;;
+stop)
+  stop
+  ;;
+status)
+  status
+  ;;
+restart|reload|condrestart)
+  restart
+  ;;
+*)
+  echo  $"Usage: $0 {start|stop|restart|reload|status}"
+  exit 1
+esac
+exit $?

--- a/modules/wso2is/templates/wso2is.service.erb
+++ b/modules/wso2is/templates/wso2is.service.erb
@@ -1,0 +1,19 @@
+[Unit]
+Description=WSO2IS
+After=network.target
+
+[Service]
+ExecStart=<%=@install_path%>/bin/wso2server.sh start
+ExecStop=<%=@install_path%>/bin/wso2server.sh stop
+ExecRestart=<%=@install_path%>/bin/wso2server.sh restart
+PIDFile=<%=@install_path%>/wso2carbon.pid
+User=root
+Group=root
+Type=forking
+Restart=on-failure
+RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Purpose
> Add Puppet 5 manifest scripts for IS 5.6.0. 
> Fixes #45 

## Goals
> Previous Puppet manifests were created for Puppet 3. These new manifests are for Puppet 5, and the new design is much simplified allowing users to easily understand.

## Approach
> Using the newly created Debian or RPM packages to install WSO2 Identity Server 5.6.0.

## Test environment
> JDK - Open JDK 1.8
> OS - Linux 18.04 ( Bionic Beaver)
> Puppet - Version 5.4.0
