### PR TITLE
Backup creation before applying updates

### DIFF
--- a/modules/is/manifests/init.pp
+++ b/modules/is/manifests/init.pp
@@ -59,14 +59,11 @@ class is inherits is::params {
   * WSO2 Distribution
   */
 
-  # Create distribution path
-  file { [  "${products_dir}",
-    "${products_dir}/${product}" ]:
-    ensure => 'directory',
-  }
-
   # Change the ownership of the installation directory to specified user & group
-  file { $distribution_path:
+  file { [ "${products_dir}",
+    "${products_dir}/${product}",
+    "${distribution_path}",
+    "${distribution_path}/backup" ]:
     ensure  => directory,
     owner   => $user,
     group   => $user_group,
@@ -101,9 +98,18 @@ class is inherits is::params {
     refreshonly => true,
   }
 
-  # Delete existing setup
-  exec { "detele-pack":
-    command     => "rm -rf ${install_path}",
+  # Delete previous backup
+  exec { "delete-backup":
+    command     => "rm -rf ${distribution_path}/backup/${product}-${product_version}",
+    path        => "/bin/",
+    onlyif      => "/usr/bin/test -d ${distribution_path}/backup/${product}-${product_version}",
+    subscribe   => File["binary"],
+    refreshonly => true,
+  }
+
+  # Create backup
+  exec { "create backup":
+    command     => "mv ${install_path} ${distribution_path}/backup",
     path        => "/bin/",
     onlyif      => "/usr/bin/test -d ${install_path}",
     subscribe   => File["binary"],

--- a/modules/is/manifests/init.pp
+++ b/modules/is/manifests/init.pp
@@ -85,7 +85,7 @@ class is inherits is::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
+    command     => "sh ${install_path}/bin/wso2server.sh stop",
     path        => "/bin/",
     onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
     subscribe   => File["binary"],

--- a/modules/is_analytics_dashboard/manifests/init.pp
+++ b/modules/is_analytics_dashboard/manifests/init.pp
@@ -61,15 +61,12 @@ class is_analytics_dashboard inherits is_analytics_dashboard::params {
   * WSO2 Distribution
   */
 
-  # Create distribution path
-  file { [  "${products_dir}",
-    "${products_dir}/${product}",
-    "${products_dir}/${product}/${profile}" ]:
-    ensure => 'directory',
-  }
-
   # Change the ownership of the installation directory to specified user & group
-  file { $distribution_path:
+  file { [ "${products_dir}",
+    "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}",
+    "${distribution_path}",
+    "${distribution_path}/backup" ]:
     ensure  => directory,
     owner   => $user,
     group   => $user_group,
@@ -104,9 +101,18 @@ class is_analytics_dashboard inherits is_analytics_dashboard::params {
     refreshonly => true,
   }
 
-  # Delete existing setup
-  exec { "detele-pack":
-    command     => "rm -rf ${install_path}",
+  # Delete previous backup
+  exec { "delete-backup":
+    command     => "rm -rf ${distribution_path}/backup/${product}-${product_version}",
+    path        => "/bin/",
+    onlyif      => "/usr/bin/test -d ${distribution_path}/backup/${product}-${product_version}",
+    subscribe   => File["binary"],
+    refreshonly => true,
+  }
+
+  # Create backup
+  exec { "create backup":
+    command     => "mv ${install_path} ${distribution_path}/backup",
     path        => "/bin/",
     onlyif      => "/usr/bin/test -d ${install_path}",
     subscribe   => File["binary"],

--- a/modules/is_analytics_dashboard/manifests/init.pp
+++ b/modules/is_analytics_dashboard/manifests/init.pp
@@ -88,7 +88,7 @@ class is_analytics_dashboard inherits is_analytics_dashboard::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2/${profile}/runtime.pid)",
+    command     => "sh ${install_path}/bin/${profile}.sh stop",
     path        => "/bin/",
     onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/runtime.pid",
     subscribe   => File["binary"],

--- a/modules/is_analytics_worker/manifests/init.pp
+++ b/modules/is_analytics_worker/manifests/init.pp
@@ -88,7 +88,7 @@ class is_analytics_worker inherits is_analytics_worker::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2/${profile}/runtime.pid)",
+    command     => "sh ${install_path}/bin/${profile}.sh stop",
     path        => "/bin/",
     onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/runtime.pid",
     subscribe   => File["binary"],

--- a/modules/is_analytics_worker/manifests/init.pp
+++ b/modules/is_analytics_worker/manifests/init.pp
@@ -61,15 +61,12 @@ class is_analytics_worker inherits is_analytics_worker::params {
   * WSO2 Distribution
   */
 
-  # Create distribution path
-  file { [  "${products_dir}",
-    "${products_dir}/${product}",
-    "${products_dir}/${product}/${profile}" ]:
-    ensure => 'directory',
-  }
-
   # Change the ownership of the installation directory to specified user & group
-  file { $distribution_path:
+  file { [ "${products_dir}",
+    "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}",
+    "${distribution_path}",
+    "${distribution_path}/backup" ]:
     ensure  => directory,
     owner   => $user,
     group   => $user_group,
@@ -104,9 +101,18 @@ class is_analytics_worker inherits is_analytics_worker::params {
     refreshonly => true,
   }
 
-  # Delete existing setup
-  exec { "detele-pack":
-    command     => "rm -rf ${install_path}",
+  # Delete previous backup
+  exec { "delete-backup":
+    command     => "rm -rf ${distribution_path}/backup/${product}-${product_version}",
+    path        => "/bin/",
+    onlyif      => "/usr/bin/test -d ${distribution_path}/backup/${product}-${product_version}",
+    subscribe   => File["binary"],
+    refreshonly => true,
+  }
+
+  # Create backup
+  exec { "create backup":
+    command     => "mv ${install_path} ${distribution_path}/backup",
     path        => "/bin/",
     onlyif      => "/usr/bin/test -d ${install_path}",
     subscribe   => File["binary"],


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/puppet-is/issues/82, Resolves https://github.com/wso2/puppet-is/issues/83

## Goals
> Stop server on agents using shell script, and create backups before updates are applied.

## Test environment
> Puppet 5.4.0
> Ubuntu 18.04