### PR TITLE
Add BPS and Consent datasource parameters

### DIFF
--- a/modules/is/manifests/params.pp
+++ b/modules/is/manifests/params.pp
@@ -64,6 +64,18 @@ class is::params inherits is_common::params {
   $shared_db_driver = 'org.h2.Driver'
   $shared_db_validation_query = 'SELECT 1'
 
+  $bps_db_url = 'jdbc:h2:file:./repository/database/jpadb;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE'
+  $bps_db_username = 'wso2carbon'
+  $bps_db_password = 'wso2carbon'
+  $bps_db_driver = 'org.h2.Driver'
+  $bps_db_validation_query = 'SELECT 1'
+
+  $consent_db_url = 'dbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE'
+  $consent_db_username = 'wso2carbon'
+  $consent_db_password = 'wso2carbon'
+  $consent_db_driver = 'org.h2.Driver'
+  $consent_db_validation_query = 'SELECT 1'
+
   # ----- Security config params -----
   $security_keystore_location = 'wso2carbon.jks'
   $security_keystore_type = 'JKS'

--- a/modules/is/templates/carbon-home/repository/conf/deployment.toml.erb
+++ b/modules/is/templates/carbon-home/repository/conf/deployment.toml.erb
@@ -52,6 +52,29 @@ driver = "<%= @shared_db_driver %>"
 [database.shared_db.pool_options]
 validationQuery="<%= @shared_db_validation_query %>"
 
+[database.bps_database]
+url = "<%= @bps_db_url %>"
+username = "<%= @bps_db_username %>"
+password = "<%= @bps_db_password %>"
+driver = "<%= @bps_db_driver %>"
+[database.bps_database.pool_options]
+validationQuery = "<%= @bps_db_validation_query %>"
+
+[[datasource]]
+id = "WSO2ConsentDS"
+url = "<%= @consent_db_url %>"
+username = "<%= @consent_db_username %>"
+password = "<%= @consent_db_password %>"
+driver = "<%= @consent_db_driver %>"
+pool_options.validationQuery= "<%= @consent_db_validation_query %>"
+pool_options.maxActive=50
+pool_options.maxWait = 60000 # wait in milliseconds
+pool_options.testOnBorrow = true
+pool_options.jmxEnabled = false
+
+[authentication.consent]
+data_source="jdbc/WSO2ConsentDS"
+
 [keystore.tls]
 password = "<%= @security_keystore_password %>"
 file_name = "<%= @security_keystore_location %>"


### PR DESCRIPTION
## Purpose
> Resolves #114 

## Goals
> Update the data source configurations to include BPS and Consent databases

## Test environment
> Puppet 5.4.0
> Ubuntu 18.04