### PR TITLE
Fix block name

### DIFF
--- a/modules/is/templates/carbon-home/repository/conf/deployment.toml.erb
+++ b/modules/is/templates/carbon-home/repository/conf/deployment.toml.erb
@@ -75,7 +75,7 @@ pool_options.jmxEnabled = false
 [authentication.consent]
 data_source="jdbc/WSO2ConsentDS"
 
-[keystore.tls]
+[keystore.primary]
 password = "<%= @security_keystore_password %>"
 file_name = "<%= @security_keystore_location %>"
 type = "<%= @security_keystore_type %>"


### PR DESCRIPTION
## Purpose
Fixes #120 

## Goals

## Approach
Changed the block name from [keystore.tls] to [keystore.primary] in the deployment.toml file

## User stories

## Release note

## Documentation

## Training

## Certification
N/A
This is related to puppet modules

## Marketing

## Automation tests

## Security checks

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
 
## Learning
